### PR TITLE
Fix #17

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,6 +56,7 @@ apps:
       - gsettings
       - pulseaudio
       - opengl
+      - removable-media
     environment:
       DISABLE_WAYLAND: '1'
       GTK_USE_PORTAL: "1"


### PR DESCRIPTION
Fixes #17 by adding a removable-media plug so that users can access user files which are outside of /home.

Not tested as this seems a trivial change which can be tested when pushed to `edge`?