### PR TITLE
Remove vendored shared libraries. Close #22

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,6 +48,8 @@ parts:
       snapcraftctl set-version "$VERSION"
     prime:
       - -opt/Signal/chrome-sandbox
+      - -opt/Signal/resources/app.asar.unpacked
+
   cleanup:
     after: [ signal-desktop ]
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,9 +58,10 @@ parts:
         set -eux
         cd /snap/gnome-3-28-1804/current
         find . -type f,l -exec rm -f $SNAPCRAFT_PRIME/{} \;
-        for CRUFT in bug doc lintian man; do
+        for CRUFT in bug lintian man; do
           rm -rf $SNAPCRAFT_PRIME/usr/share/$CRUFT
         done
+        find $SNAPCRAFT_PRIME/usr/share/doc/ -type f -not -name 'copyright' -delete
 
 apps:
   signal-desktop:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,6 +58,9 @@ parts:
         set -eux
         cd /snap/gnome-3-28-1804/current
         find . -type f,l -exec rm -f $SNAPCRAFT_PRIME/{} \;
+        for CRUFT in bug doc lintian man; do
+          rm -rf $SNAPCRAFT_PRIME/usr/share/$CRUFT
+        done
 
 apps:
   signal-desktop:


### PR DESCRIPTION
Signal bundles an unpacked asar which includes shared libraries that are ABI incompatible with the GNOME platform snap.  This PR removes the unpacked asar to remedy the problem.