### PR TITLE
Leave the app.asar.unpacked in the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,6 @@ parts:
       snapcraftctl set-version "$VERSION"
     prime:
       - -opt/Signal/chrome-sandbox
-      - -opt/Signal/resources/app.asar.unpacked
 
   cleanup:
     after: [ signal-desktop ]


### PR DESCRIPTION
Signal Desktop 1.34 requires assets from the unpacked asar.
