### PR TITLE
Add missing audio-record and camera plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,10 +73,12 @@ apps:
     command: opt/Signal/signal-desktop --use-tray-icon --no-sandbox
     plugs:
       - browser-support
+      - camera
       - home
       - network
       - opengl
       - audio-playback
+      - audio-record
       - removable-media
       - unity7
       - desktop


### PR DESCRIPTION
Fixes #44 

Audio and video calls are now available on the Signal-Desktop app.