### PR TITLE
Set license to AGPL-3.0-only

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,6 +4,7 @@ adopt-info: signal-desktop
 summary: Signal Desktop
 description: |
   Private messaging from your desktop.
+license: AGPL-3.0-only
 
 grade: stable
 confinement: strict


### PR DESCRIPTION
Maybe fixes #47 unless that needs to be configured in the settings at
https://snapcraft.io/signal-desktop/listing