### PR TITLE
Wayland seems to be supported now: undo the disabling

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -97,7 +97,5 @@ apps:
       - desktop
       - desktop-legacy
     environment:
-      DISABLE_WAYLAND: '1'
       GTK_USE_PORTAL: "1"
       TMPDIR: $XDG_RUNTIME_DIR
-      WAYLAND_DISPLAY: no-display


### PR DESCRIPTION
Video and audio calls untested.

I appreciate that we're still waiting for the Snap Store to release the lock on Signal Desktop, but I thought we could prepare by enabling Wayland while we wait.

Signed-off-by: Dani Llewellyn <diddledani@ubuntu.com>