### PR TITLE
Enable automatic syncing with upstream

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -20,7 +20,7 @@ jobs:
             curl -sL https://api.github.com/repos/signalapp/Signal-Desktop/releases | 
             jq .  | grep tag_name | grep -v beta | head -n 1 | cut -d'"' -f4 | tr -d 'v'
           )
-          sed 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml
+          sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml
       - name: Check for modified files
         id: git-check
         run: echo ::set-output name=modified::$([ -z "`git status --porcelain`" ] && echo "false" || echo "true")

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -11,7 +11,7 @@ jobs:
   get-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.REPO_SCOPED_TOKEN }}
       - name: Fetch release version

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -23,7 +23,9 @@ jobs:
           sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml
       - name: Check for modified files
         id: git-check
-        run: echo ::set-output name=modified::$([ -z "`git status --porcelain`" ] && echo "false" || echo "true")
+        run: |
+          MODIFIED=$([ -z "`git status --porcelain`" ] && echo "false" || echo "true")
+          echo "modified=$MODIFIED" >> $GITHUB_OUTPUT
       - name: Commit latest release version
         if: steps.git-check.outputs.modified == 'true'
         run: |

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -1,0 +1,33 @@
+name: Sync with upstream
+
+on:
+  # Runs at 10:00 UTC every day
+  schedule:
+    - cron:  '0 10 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.REPO_SCOPED_TOKEN }}
+      - name: Fetch release version
+        run: |
+          VERSION=$(
+            curl -sL https://api.github.com/repos/signalapp/Signal-Desktop/releases | 
+            jq .  | grep tag_name | grep -v beta | head -n 1 | cut -d'"' -f4 | tr -d 'v'
+          )
+          sed 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml
+      - name: Check for modified files
+        id: git-check
+        run: echo ::set-output name=modified::$([ -z "`git status --porcelain`" ] && echo "false" || echo "true")
+      - name: Commit latest release version
+        if: steps.git-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'Sync Workflow'
+          git config --global user.email 'merlijn.sebrechts@gmail.com'
+          git commit -am "Automatic sync to latest release"
+          git push

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04  # https://github.com/snapcore/action-build/issues/42
 
     steps:
       - uses: actions/checkout@v3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,6 +33,7 @@ parts:
       - gcc
       - dpkg
       - git
+      - wget
     stage-packages:
       - libxss1
       - libnspr4

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@ description: |
 license: AGPL-3.0-only
 adopt-info: signal-desktop
 icon: snap/gui/signal-desktop.png
-version: 5.63.1
+version: 6.0.0
 
 base: core22
 grade: stable

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,9 +31,9 @@ parts:
     plugin: nil
     build-packages:
       - gcc
+      - wget
       - dpkg
       - git
-      - wget
     stage-packages:
       - libxss1
       - libnspr4
@@ -46,7 +46,7 @@ parts:
       DEB_URL="https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_"$VERSION"_amd64.deb"
       wget --quiet $DEB_URL -O signal.deb
       dpkg-deb -x signal.deb $CRAFT_PART_INSTALL/
-      rm signal.deb releases.json
+      rm signal.deb
       sed -i 's|Icon=signal-desktop|Icon=${SNAP}/usr/share/icons/hicolor/512x512/apps/signal-desktop.png|' $CRAFT_PART_INSTALL/usr/share/applications/signal-desktop.desktop
       craftctl set version=$VERSION
     prime:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,10 +35,6 @@ parts:
       - libnspr4
       - libnss3
       - libvips42
-    override-build: |
-        set -xeu
-        craftctl default
-        sed -i 's|Icon=signal-desktop|Icon=${SNAP}/usr/share/icons/hicolor/512x512/apps/signal-desktop.png|' $CRAFT_PART_INSTALL/usr/share/applications/signal-desktop.desktop
     prime:
       - opt
       - usr/share

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,6 +16,7 @@ description: |
 license: AGPL-3.0-only
 adopt-info: signal-desktop
 icon: snap/gui/signal-desktop.png
+version: 5.63.0
 
 base: core22
 grade: stable
@@ -30,8 +31,6 @@ parts:
     plugin: nil
     build-packages:
       - gcc
-      - wget
-      - jq
       - dpkg
       - git
     stage-packages:
@@ -42,9 +41,7 @@ parts:
     override-build: |
       set -xeu
       echo "Get GitHub releases..."
-      wget --quiet https://api.github.com/repos/signalapp/Signal-Desktop/releases -O releases.json
-      # Get the version from the tag_name and the download URL.
-      VERSION=$(jq . releases.json | grep tag_name | grep -v beta | head -n 1 | cut -d'"' -f4 | tr -d 'v')
+      VERSION=$(craftctl get version)
       DEB_URL="https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_"$VERSION"_amd64.deb"
       wget --quiet $DEB_URL -O signal.deb
       dpkg-deb -x signal.deb $CRAFT_PART_INSTALL/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,27 +28,17 @@ compression: lzo
 
 parts:
   signal-desktop:
-    plugin: nil
-    build-packages:
-      - gcc
-      - wget
-      - dpkg
-      - git
+    plugin: dump
+    source: https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_$SNAPCRAFT_PROJECT_VERSION_amd64.deb
     stage-packages:
       - libxss1
       - libnspr4
       - libnss3
       - libvips42
     override-build: |
-      set -xeu
-      echo "Get GitHub releases..."
-      VERSION=$(craftctl get version)
-      DEB_URL="https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_"$VERSION"_amd64.deb"
-      wget --quiet $DEB_URL -O signal.deb
-      dpkg-deb -x signal.deb $CRAFT_PART_INSTALL/
-      rm signal.deb
-      sed -i 's|Icon=signal-desktop|Icon=${SNAP}/usr/share/icons/hicolor/512x512/apps/signal-desktop.png|' $CRAFT_PART_INSTALL/usr/share/applications/signal-desktop.desktop
-      craftctl set version=$VERSION
+        set -xeu
+        craftctl default
+        sed -i 's|Icon=signal-desktop|Icon=${SNAP}/usr/share/icons/hicolor/512x512/apps/signal-desktop.png|' $CRAFT_PART_INSTALL/usr/share/applications/signal-desktop.desktop
     prime:
       - opt
       - usr/share

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@ description: |
 license: AGPL-3.0-only
 adopt-info: signal-desktop
 icon: snap/gui/signal-desktop.png
-version: 5.63.0
+version: 5.63.1
 
 base: core22
 grade: stable


### PR DESCRIPTION
To make it easier to keep this snap up to date, I propose to add this action that updates the repo automatically when a new release is detected. (this automatically runs daily)

So the new workflow is:

* Action detects a new version and commits it
* Store detects changes and rebuilds to edge
* We test and manually push to stable

This should make my job a lot easier. What do you think? The main downside I see is that I have to give myself permission to override branch protections (or create a new bot account specially for this?)

PS: In the future, I'd like the building and publishing to also happen using actions, so we can publish to `candidate` instead, and I can get a notification when it's ready for testing.

