### PR TITLE
Add complete automation for releasing new versions

### DIFF
--- a/.github/testing-issue-template.md
+++ b/.github/testing-issue-template.md
@@ -1,0 +1,13 @@
+---
+title: Call for testing `{{ env.SNAP_NAME }}`
+labels: testing
+---
+A new version of `{{ env.SNAP_NAME }}` was just pushed to the `{{ env.CHANNEL }}` channel [in the snap store](https://snapcraft.io/{{ env.SNAP_NAME }}). Please test it and add a comment to state whether everything works or not.
+
+You can upgrade to this version by running
+
+```shell
+snap refresh {{ env.SNAP_NAME }} --{{ env.CHANNEL }}
+```
+
+Maintainers can promote this to stable by commenting `/promote <revision-number> stable`.

--- a/.github/workflows/snap-store-promote-to-stable.yml
+++ b/.github/workflows/snap-store-promote-to-stable.yml
@@ -1,0 +1,75 @@
+name: 📦 Promote to stable
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  issues: write
+
+env:
+  SNAP_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    if: |
+      ( !github.event.issue.pull_request )
+      && contains(fromJson('["OWNER", "COLLABORATOR"]'), github.event.comment.author_association)
+      && contains(github.event.comment.body, '/promote ')
+      && contains(github.event.*.labels.*.name, 'testing')
+    steps:
+      - id: command
+        uses: xt0rted/slash-command-action@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          command: promote
+          reaction: "true"
+          reaction-type: "eyes"
+          allow-edits: "false"
+          permission-level: admin
+      - id: promote
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN_PROMOTE }}
+        run: |
+          echo "The command was '${{ steps.command.outputs.command-name }}' with arguments '${{ steps.command.outputs.command-arguments }}'"
+          arguments=(${{ steps.command.outputs.command-arguments }})
+          revision=${arguments[0]}
+          channel=${arguments[1]}
+          
+          # Sanity checks
+          re='^[0-9]+$'
+          if [[ ! "$revision" =~ $re ]]; then
+            echo "revision must be a number, not '$revision'!"
+            exit 1
+          fi
+          if [[ "$channel" != "stable"  ]]; then
+            echo "I can only promote to stable, not '$channel'!"
+            exit 1
+          fi 
+
+          # Install Snapcraft
+          sudo snap install --classic snapcraft
+          sudo chown root:root /
+
+          # Release
+          snapcraft release $SNAP_NAME "$revision" "$channel"
+
+          echo "revision=$revision" >> $GITHUB_OUTPUT
+          echo "channel=$channel" >> $GITHUB_OUTPUT
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Great, revision `${{ steps.promote.outputs.revision }}` version is now in `${{ steps.promote.outputs.channel }}`!'
+            })
+            github.rest.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed'
+            })

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -1,0 +1,48 @@
+name: 📦 Publish to candidate
+
+on:
+  push:
+    branches: [ "candidate" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Permissions for GITHUB_TOKEN
+permissions:
+  contents: read
+  issues: write
+
+env:
+  # Use the name of the repo as the name of the snap
+  SNAP_NAME: ${{ github.event.repository.name }}
+  # Use the name of the branch as the name of the channel
+  CHANNEL: ${{ github.ref_name }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: snapcore/action-build@v1
+        id: build
+      - uses: diddlesnaps/snapcraft-review-action@v1
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          isClassic: 'false'
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN_PUBLISH }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: ${{ env.CHANNEL }}
+          
+  create_issue:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/testing-issue-template.md

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -1,4 +1,4 @@
-name: Sync with upstream
+name: 🔄 Sync version with upstream
 
 on:
   # Runs at 10:00 UTC every day
@@ -7,13 +7,17 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Permissions for GITHUB_TOKEN
+permissions:
+  contents: read
+
 jobs:
   get-version:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.REPO_SCOPED_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Fetch release version
         run: |
           VERSION=$(

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,14 +1,16 @@
 name: 🧪 Test snap can be built on x86_64
 
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "**" ]
+
+# Permissions for GITHUB_TOKEN
+permissions:
+  contents: read
 
 jobs:
   build:
-    runs-on: ubuntu-20.04  # https://github.com/snapcore/action-build/issues/42
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -4,15 +4,13 @@
 
 <p align="center"><b>This is the snap for Signal Desktop</b>. It is a community-maintained package to easily install Signal Desktop on Ubuntu, Fedora, Debian and other major Linux distributions. It is available in the Snap Store, Ubuntu Software, and a number of other applications.</p>
 
-<p align="center"><i>"Signal Desktop is a private messaging app for your desktop"</p>
+<p align="center"><i>"Signal Desktop is a private messaging app for your desktop"</i></p>
 
 <p align="center">
 <a href="https://snapcraft.io/signal-desktop"><img src="https://snapcraft.io/signal-desktop/badge.svg" alt="Snap Status"></a>
 </p>
 
 ## Install
-
-### From snap store
 
 ```shell
 snap install signal-desktop
@@ -22,21 +20,64 @@ snap install signal-desktop
 
 <p align="center">Published for <img src="https://raw.githubusercontent.com/anythingcodes/slack-emoji-for-techies/gh-pages/emoji/tux.png" align="top" width="24" /> with :gift_heart: by Snapcrafters</p>
 
-### Building snap locally
+## How to contribute to this snap
 
-``` bash
-sudo snap install --classic snapcraft
-git clone https://github.com/snapcrafters/signal-desktop.git
-cd signal-desktop
-snapcraft
-sudo snap install --dangerous signal-desktop_*.snap
+Thanks for your interest! Below you find instructions to help you contribute to this snap.
+
+The general workflow is to submit pull requests that merges your changes into the `candidate` branch here on GitHub. Once the pull request has been merged, a GitHub action will automatically build the snap and publish it to the `candidate` channel in the Snap Store. Once the snap has been tested thoroughly, we promote it to the `stable` channel so all our users get it!
+
+### Initial setup
+
+If this is your first time contributing to this snap, you first need to set up your own fork of this repository.
+
+1. [Fork the repository](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) into your own GitHub namespace.
+2. [Clone your fork](https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository), so that you have it on your local computer.
+3. Configure your local repo. To make things a bit more intuitive, we will rename your fork's remote to `myfork`, and add the snapcrafters repo as `snapcrafters`.
+
+   ```shell
+   git remote rename origin myfork
+   git remote add snapcrafters https://github.com/snapcrafters/signal-desktop.git
+   git fetch --all
+   ```
+
+### Submitting changes in a pull request
+
+Once you're all setup for contributing, keep in mind that you want the git information to be all up-to-date. So if you haven't "fetched" all changes in a while, start with that:
+
+```shell
+git fetch --all -p
 ```
 
-Notes: 
-1. Agree to install `multipass` if asked to
-2. `snap install --dangerous` is used as your snap package you just built locally won't have any pre-acknowledged signature for it
+Now that your git metadata has been updated you are ready to create a bugfix branch, make your changes, and open a pull request.
+
+1. All pull requests should go to the stable branch so create your branch as a copy of the stable branch:
+
+   ```shell
+   git checkout -b my-bugfix-branch snapcrafters/candidate
+   ```
+
+2. Make your desired changes and build a snap locally for testing:
+
+   ```shell
+   snapcraft --use-lxd
+   ```
+
+3. After you are happy with your changes, commit them and push them to your fork so they are available on GitHub:
+
+   ```shell
+   git commit -a
+   git push -u myfork my-bugfix-branch
+   ```
+
+4. Then, [open up a pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) from your `my-bugfix-branch` to the `snapcrafters/candidate` branch.
+5. Once you've opened the pull request, it will automatically trigger the build-test action that will launch a build of the snap. You can watch the progress of the snap build from your pull request (Show all checks -> Details). Once the snap build has completed, you can find the built snap (to test with) under "Artifacts".
+6. Someone from the team will review the open pull request and either merge it or start a discussion with you with additional changes or clarification needed.
+7. Once the pull request has been merged into the stable branch, a GitHub action will rebuild the snap using your changes and publish it to the [Snap Store](https://snapcraft.io/signal-desktop) into the `candidate` channel. After sufficient testing of the snap from the candidate channel, one of the maintainers or administrators will promote the snap to the stable branch in the Snap Store.
+
+## Maintainers
+
+* [@merlijn-sebrechts](https://github.com/merlijn-sebrechts/)
 
 ## License
 
-* The license of the build files in this repository is GNU Affero General Public License v3.0 only
-* Signal Desktop itself has [its own license](https://github.com/signalapp/Signal-Desktop/blob/main/LICENSE).
+* The license of both the build files in this repository and Signal Desktop itself is [GNU Affero General Public License v3.0 only](https://github.com/signalapp/Signal-Desktop/blob/main/LICENSE)


### PR DESCRIPTION
**This PR completely automates the updating of the app version inside this snap.**

1. [sync-version-with-upstream.yml](https://github.com/merlijn-sebrechts/signal-desktop/blob/add-automation/.github/workflows/sync-version-with-upstream.yml) runs daily to sync the version in our repos with the upstream released version.
2. [snap-store-publish-to-candidate.yml](https://github.com/merlijn-sebrechts/signal-desktop/blob/add-automation/.github/workflows/snap-store-publish-to-candidate.yml) runs every time a commit happens to the `candidate` branch. It
   * Builds the snap, tests it, and pushes it to `candidate` channel in the store.
   * Creates a "call for testing" issue stating a new version is available to test
3. [snap-store-promote-to-stable.yml](https://github.com/merlijn-sebrechts/signal-desktop/blob/add-automation/.github/workflows/snap-store-promote-to-stable.yml) runs every time a comment gets added to a call for testing. It
   * Checks if the comment is a command of type `promote <revision> stable` from a person who's either an owner or collaborator on the repo.
   * If so, promotes that revision to the `stable` channel in the snap store
   * And closes the call for testing.

**credentials**

* `GITHUB_TOKEN` is the [automatic authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) used to push to the repo and create/edit issues. This has granular permissions defined in each workflow.
* `STORE_LOGIN_PUBLISH` is a token I generated myself with
   ```shell
   snapcraft export-login --snaps=signal-desktop \
      --acls package_access,package_push,package_update,package_release \
      --channels candidate \
      --expires 2023-12-07
   ````
* `STORE_LOGIN_PROMOTE` is a token I generated myself with
   ```shell
   snapcraft export-login --snaps=signal-desktop \
     --acls package_access,package_release \
     --channels stable \
     --expires 2023-12-07
   ```

**To see it in action**:

* Building and creating the issue: https://github.com/merlijn-sebrechts/signal-desktop/actions/runs/3670841691
* Promoting it to stable: https://github.com/merlijn-sebrechts/signal-desktop/actions/runs/3670881082/jobs/6205707692



fixes https://github.com/snapcrafters/signal-desktop/issues/58