### PR TITLE
Fix the workflows

### DIFF
--- a/.github/workflows/snap-store-promote-to-stable.yml
+++ b/.github/workflows/snap-store-promote-to-stable.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       ( !github.event.issue.pull_request )
-      && contains(fromJson('["OWNER", "COLLABORATOR"]'), github.event.comment.author_association)
       && contains(github.event.comment.body, '/promote ')
       && contains(github.event.*.labels.*.name, 'testing')
     steps:
@@ -73,3 +72,6 @@ jobs:
               repo: context.repo.repo,
               state: 'closed'
             })
+      - name: Dump GitHub context
+        id: github_context_step
+        run: echo '${{ toJSON(github) }}'

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -9,7 +9,7 @@ on:
 
 # Permissions for GITHUB_TOKEN
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   get-version:

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Commit latest release version
         if: steps.git-check.outputs.modified == 'true'
         run: |
-          git config --global user.name 'Sync Workflow'
+          git config --global user.name 'github-actions [bot]'
           git config --global user.email 'merlijn.sebrechts@gmail.com'
           git commit -am "Automatic sync to latest release"
           git push


### PR DESCRIPTION
There were still two issues with my initial automation proposal:

* The permissions for the sync job were incorrect. I did not test this initially, but I tested it now.
* The `author_association` seems to be different for org repos, compared to my own. I have removed this requirement from the workflow for now, as the action itself also checks whether the person is allowed to promote. I also added a log action at the end, so I can see how the `author_association` is different, and if we can maybe add a different rule in the future. It wouldn't hurt to check authorization twice in the future.