### PR TITLE
Updated URL for deb files

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,7 +40,7 @@ compression: lzo
 parts:
   signal-desktop:
     plugin: dump
-    source: https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_$SNAPCRAFT_PROJECT_VERSION_amd64.deb
+    source: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_$SNAPCRAFT_PROJECT_VERSION_amd64.deb
     stage-packages:
       - libxss1
       - libnspr4


### PR DESCRIPTION
It appears that Signal changed a URL where deb files are stored since version 6.20.1. This caused a problem, that snap is not updated to the latest version. This PR changes this URL to a correct one.