### PR TITLE
Fix two issues being created for each sync

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -38,14 +38,3 @@ jobs:
           git push
     outputs:
       modified: ${{ steps.git-check.outputs.modified }}
-  call-snap-store-publish-to-candidate:
-    name: "Call"
-    needs: sync-version
-    if: needs.sync-version.outputs.modified == 'true'
-    # Permissions needed by the called workflow
-    permissions:
-      contents: read
-      issues: write
-    secrets:
-      SNAP_STORE_CANDIDATE: ${{ secrets.SNAP_STORE_CANDIDATE }}
-    uses: ./.github/workflows/snap-store-publish-to-candidate.yml


### PR DESCRIPTION
The sync-version-with-upstream previously had to manually call the build action because pushes were done by `snapcrafters-bot` when it was still quarantined. Since the quarantine ended a while ago, their pushes trigger other actions, so we don't need to call it manually anymore.