### PR TITLE
Build Signal from source (and enable arm64 builds)

### DIFF
--- a/snap/gui/signal-desktop.desktop
+++ b/snap/gui/signal-desktop.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Signal
+Exec=signal-desktop --no-sandbox %U
+Terminal=false
+Type=Application
+Icon=${SNAP}/meta/gui/signal-desktop.png
+StartupWMClass=Signal
+Comment=Private messaging from your desktop
+MimeType=x-scheme-handler/sgnl;x-scheme-handler/signalcaptcha;
+Categories=Network;InstantMessaging;Chat;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,12 +35,117 @@ confinement: strict
 
 architectures:
   - build-on: amd64
+  - build-on: arm64
 compression: lzo
 
 parts:
   signal-desktop:
     plugin: dump
-    source: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_$SNAPCRAFT_PROJECT_VERSION_amd64.deb
+    source: https://github.com/signalapp/Signal-Desktop
+    source-type: git
+    source-tag: v$SNAPCRAFT_PROJECT_VERSION
+    build-packages:
+      - git-lfs
+      - jq
+      - moreutils
+      - python3
+      - wget
+    build-environment:
+      - SIGNAL_ENV: "production"
+      - USE_SYSTEM_FPM: "true"
+    override-build: |
+      # Set a common proxy variable, defaulting to empty if not set
+      export HTTP_PROXY="${http_proxy:-}"
+      export HTTPS_PROXY="${https_proxy:-}"
+
+      # Ensure that electron-builder respects the proxy
+      export ELECTRON_GET_USE_PROXY=1
+      export GLOBAL_AGENT_HTTP_PROXY="${HTTP_PROXY}"
+      export GLOBAL_AGENT_HTTPS_PROXY="${HTTP_PROXY}"
+
+      git lfs install
+      
+      # Disable yarn auto clean functionality
+      rm .yarnclean
+
+      # Install the version of NodeJS used by the upstream project
+      git clone -b v0.13.1 https://github.com/asdf-vm/asdf.git ./.asdf
+      source "./.asdf/asdf.sh"
+      asdf plugin add nodejs
+      asdf install nodejs 18.15.0
+      asdf global nodejs 18.15.0
+
+      # Install and configure Yarn
+      npm install -g yarn 
+      yarn config set python /usr/bin/python3
+      yarn config set proxy "$HTTP_PROXY"
+      yarn config set https-proxy "$HTTPS_PROXY"
+
+      # Don't try to build a deb (this fails on arm64)
+      cat package.json | jq '.build.linux.target = ["dir"]' | sponge package.json
+
+      # If we're in a proxy environment, we need to patch some packages
+      if [[ -n "$HTTPS_PROXY" ]]; then
+        yarn global add https-proxy-agent
+        
+        # Two lines of NodeJS code that initialise a proxy-agent-instance
+        export PROXY_PATCH="const { HttpsProxyAgent } = require('https-proxy-agent');\nconst agent = new HttpsProxyAgent('${HTTPS_PROXY}');\n"
+
+        # Vendor and patch the @signalapp/ringrtc package so it's build fetch uses a proxy
+        mkdir -p vendor/ringrtc
+        version="$(cat package.json| jq -r '.dependencies."@signalapp/ringrtc"')"
+        pushd vendor/ringrtc
+        npm pack "@signalapp/ringrtc@${version}"
+        tar xvzf "signalapp-ringrtc-${version}.tgz"
+        echo -e "${PROXY_PATCH}$(cat package/scripts/fetch-prebuild.js)" > package/scripts/fetch-prebuild.js
+        sed -i 's|https.get(URL, async res|https.get(URL, { agent }, async res|g' package/scripts/fetch-prebuild.js
+        popd
+
+        # Update the package.json so the build uses the patched library
+        cat package.json \
+          | jq -r '.dependencies."@signalapp/ringrtc"="file:./vendor/ringrtc/package"' \
+          | sponge package.json
+
+        # Vendor and patch the @signalapp/better-sqlite3 package so it's build fetch uses a proxy
+        mkdir -p vendor/better-sqlite3
+        version="$(cat package.json| jq -r '.dependencies."@signalapp/better-sqlite3"')"
+        pushd vendor/better-sqlite3
+        npm pack "@signalapp/better-sqlite3@${version}"
+        tar xvzf "signalapp-better-sqlite3-${version}.tgz"
+        echo -e "${PROXY_PATCH}$(cat package/deps/download.js)" > package/deps/download.js
+        sed -i 's|https.get(URL, async (res)|https.get(URL, { agent }, async (res)|g' package/deps/download.js
+        popd
+
+        # Update the package.json so the build uses the patched library
+        cat package.json \
+          | jq -r '.dependencies."@signalapp/better-sqlite3"="file:./vendor/better-sqlite3/package"' \
+          | sponge package.json
+      fi
+
+      # Install the dependencies for the Signal-Desktop application.
+      # We cannot use `--frozen-lockfile` due to the modifications above
+      yarn install
+
+      # This is the equivalent of 'yarn generate'. The upstream package.json
+      # uses npm-run-all to run multiple things, which has a bug that prevents
+      # this from succeeding in the snapcraft build env, so this just breaks
+      # that apart into its component parts.
+      yarn build-protobuf
+      yarn build:esbuild
+      yarn sass 
+      yarn get-expire-time
+      yarn copy-components
+
+      # This is the equivalent of 'yarn build-linux' which also runs 'yarn generate'
+      # which is broken (as described above).
+      yarn build:esbuild:prod
+      yarn build:release --publish=never
+      yarn build:electron --config.directories.output=release
+
+      # Stage the built release. Directory is called 'linux-unpacked' for amd64,
+      # and 'linux-arm64-unpacked' for arm64.
+      mkdir -p "${CRAFT_PART_INSTALL}/opt"
+      mv release/linux-*unpacked "${CRAFT_PART_INSTALL}/opt/Signal"
     stage-packages:
       - libxss1
       - libnspr4
@@ -94,7 +199,6 @@ parts:
 apps:
   signal-desktop:
     extensions: [gnome]
-    desktop: usr/share/applications/signal-desktop.desktop
     command: opt/Signal/signal-desktop --use-tray-icon --no-sandbox
     plugs:
       - browser-support

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,14 +32,70 @@ version: 6.36.0
 base: core22
 grade: stable
 confinement: strict
+compression: lzo
 
 architectures:
   - build-on: amd64
   - build-on: arm64
-compression: lzo
 
 parts:
+  # NodeJS dependency which uses a non-proxy aware fetch during its build.
+  # The purpose of this part is to introduce proxy awareness so the build succeeds in LP.
+  ringrtc:
+    plugin: dump
+    source: https://registry.npmjs.org/@signalapp/ringrtc/-/ringrtc-2.33.0.tgz
+    override-build: |
+      # Patch the file; inject a proxy agent at the top of the file
+      cat <<-EOF > scripts/fetch-prebuild.js
+        const { HttpsProxyAgent } = require('https-proxy-agent');
+        const agent = new HttpsProxyAgent('${https_proxy:-}');
+        $(cat scripts/fetch-prebuild.js)
+      EOF
+
+      # Ensure the fetch actually uses the agent
+      sed -i 's|https.get(URL, async res|https.get(URL, { agent }, async res|g' scripts/fetch-prebuild.js
+
+  # NodeJS dependency which uses a non-proxy aware fetch during its build.
+  # The purpose of this part is to introduce proxy awareness so the build succeeds in LP.
+  better-sqlite3:
+    plugin: dump
+    source: https://registry.npmjs.org/@signalapp/better-sqlite3/-/better-sqlite3-8.5.2.tgz
+    override-build: |
+      # Patch the file; inject a proxy agent at the top of the file
+      cat <<-EOF > deps/download.js
+        const { HttpsProxyAgent } = require('https-proxy-agent');
+        const agent = new HttpsProxyAgent('${https_proxy:-}');
+        $(cat deps/download.js)
+      EOF
+
+      # Ensure the fetch actually uses the agent
+      sed -i 's|https.get(URL, async (res)|https.get(URL, { agent }, async (res)|g' deps/download.js
+
+  nodejs:
+    plugin: dump
+    source: https://github.com/asdf-vm/asdf.git
+    source-tag: v0.13.1
+    build-environment:
+      - NODE_VERSION: 18.15.0
+    override-build: |
+      source "./asdf.sh"
+
+      # Install the correct version of nodejs required by Signal-Desktop
+      asdf plugin add nodejs
+      asdf install nodejs "$NODE_VERSION"
+      asdf global nodejs "$NODE_VERSION"
+
+      # Install and configure Yarn
+      npm install -g yarn 
+      yarn config set python /usr/bin/python3
+      yarn config set proxy "${http_proxy:-}"
+      yarn config set https-proxy "${https_proxy:-}"
+
   signal-desktop:
+    after:
+      - ringrtc
+      - better-sqlite3
+      - nodejs
     plugin: dump
     source: https://github.com/signalapp/Signal-Desktop
     source-type: git
@@ -54,76 +110,39 @@ parts:
       - SIGNAL_ENV: "production"
       - USE_SYSTEM_FPM: "true"
     override-build: |
-      # Set a common proxy variable, defaulting to empty if not set
-      export HTTP_PROXY="${http_proxy:-}"
-      export HTTPS_PROXY="${https_proxy:-}"
-
-      # Ensure that electron-builder respects the proxy
-      export ELECTRON_GET_USE_PROXY=1
-      export GLOBAL_AGENT_HTTP_PROXY="${HTTP_PROXY}"
-      export GLOBAL_AGENT_HTTPS_PROXY="${HTTP_PROXY}"
+      # Use the version of nodejs/yarn we configured before
+      source "$(pwd)/../../nodejs/build/asdf.sh"
 
       git lfs install
-      
+
       # Disable yarn auto clean functionality
       rm .yarnclean
-
-      # Install the version of NodeJS used by the upstream project
-      git clone -b v0.13.1 https://github.com/asdf-vm/asdf.git ./.asdf
-      source "./.asdf/asdf.sh"
-      asdf plugin add nodejs
-      asdf install nodejs 18.15.0
-      asdf global nodejs 18.15.0
-
-      # Install and configure Yarn
-      npm install -g yarn 
-      yarn config set python /usr/bin/python3
-      yarn config set proxy "$HTTP_PROXY"
-      yarn config set https-proxy "$HTTPS_PROXY"
 
       # Don't try to build a deb (this fails on arm64)
       cat package.json | jq '.build.linux.target = ["dir"]' | sponge package.json
 
       # If we're in a proxy environment, we need to patch some packages
-      if [[ -n "$HTTPS_PROXY" ]]; then
+      if [[ -n "${http_proxy:-}" ]]; then
+        # Setup proxy access
+        export ELECTRON_GET_USE_PROXY=1
+        export GLOBAL_AGENT_HTTP_PROXY="${http_proxy}"
+        export GLOBAL_AGENT_HTTPS_PROXY="${http_proxy}"
+
+        # The patch applied uses this package to ensure proxy is used
         yarn global add https-proxy-agent
         
-        # Two lines of NodeJS code that initialise a proxy-agent-instance
-        export PROXY_PATCH="const { HttpsProxyAgent } = require('https-proxy-agent');\nconst agent = new HttpsProxyAgent('${HTTPS_PROXY}');\n"
-
-        # Vendor and patch the @signalapp/ringrtc package so it's build fetch uses a proxy
-        mkdir -p vendor/ringrtc
-        version="$(cat package.json| jq -r '.dependencies."@signalapp/ringrtc"')"
-        pushd vendor/ringrtc
-        npm pack "@signalapp/ringrtc@${version}"
-        tar xvzf "signalapp-ringrtc-${version}.tgz"
-        echo -e "${PROXY_PATCH}$(cat package/scripts/fetch-prebuild.js)" > package/scripts/fetch-prebuild.js
-        sed -i 's|https.get(URL, async res|https.get(URL, { agent }, async res|g' package/scripts/fetch-prebuild.js
-        popd
-
-        # Update the package.json so the build uses the patched library
+        # Update the package.json so the build uses the patched libraries
         cat package.json \
-          | jq -r '.dependencies."@signalapp/ringrtc"="file:./vendor/ringrtc/package"' \
+          | jq -r --arg f "file:${PWD}/../../ringrtc/build" '.dependencies."@signalapp/ringrtc"=$f' \
           | sponge package.json
 
-        # Vendor and patch the @signalapp/better-sqlite3 package so it's build fetch uses a proxy
-        mkdir -p vendor/better-sqlite3
-        version="$(cat package.json| jq -r '.dependencies."@signalapp/better-sqlite3"')"
-        pushd vendor/better-sqlite3
-        npm pack "@signalapp/better-sqlite3@${version}"
-        tar xvzf "signalapp-better-sqlite3-${version}.tgz"
-        echo -e "${PROXY_PATCH}$(cat package/deps/download.js)" > package/deps/download.js
-        sed -i 's|https.get(URL, async (res)|https.get(URL, { agent }, async (res)|g' package/deps/download.js
-        popd
-
-        # Update the package.json so the build uses the patched library
         cat package.json \
-          | jq -r '.dependencies."@signalapp/better-sqlite3"="file:./vendor/better-sqlite3/package"' \
+          | jq -r --arg f "file:${PWD}/../../better-sqlite3/build" '.dependencies."@signalapp/better-sqlite3"=$f' \
           | sponge package.json
       fi
 
       # Install the dependencies for the Signal-Desktop application.
-      # We cannot use `--frozen-lockfile` due to the modifications above
+      # We cannot use `--frozen-lockfile` due to the patching above.
       yarn install
 
       # This is the equivalent of 'yarn generate'. The upstream package.json


### PR DESCRIPTION
This PR switches to enable build from source for Signal Desktop - the primary motivation is to enable builds for arm64. At present Signal does not provide an upstream deb for other architectures, so this is the only viable option I see.

There is a small difficulty which I've worked around, which is that the upstream `package.json` uses `npm-run-all` to run multiple targets as part of `yarn generate`. This was causing the scriptlets to exit early, so I've broken apart those targets into their component parts - but otherwise the process is as per their documentation.

Fixes #178 