### PR TITLE
ci: automatically bump node parts and use remote build

### DIFF
--- a/.github/testing-issue-template.md
+++ b/.github/testing-issue-template.md
@@ -2,7 +2,10 @@
 title: Call for testing `{{ env.SNAP_NAME }}`
 labels: testing
 ---
-A new version of `{{ env.SNAP_NAME }}` was just pushed to the `{{ env.CHANNEL }}` channel [in the snap store](https://snapcraft.io/{{ env.SNAP_NAME }}). Please test it and add a comment to state whether everything works or not.
+
+A new version of `{{ env.SNAP_NAME }}` was just pushed to the `{{ env.CHANNEL }}` channel [in the
+snap store](https://snapcraft.io/{{ env.SNAP_NAME }}). Please test it and add a comment to state
+whether everything works or not.
 
 You can upgrade to this version by running
 
@@ -10,4 +13,9 @@ You can upgrade to this version by running
 snap refresh {{ env.SNAP_NAME }} --{{ env.CHANNEL }}
 ```
 
-Maintainers can promote this to stable by commenting `/promote <revision-number> stable`.
+Maintainers can promote this to stable by commenting `/promote <rev>[,<rev>] stable`.
+
+The `/promote` command must be issued with at least one revision and a channel, for example
+`/promote 34 stable`. Multiple revisions can also be promoted at once where required (this is
+useful where there are new arm64 and amd64 revisions at the same time), for example `/promote 34,35
+stable`.

--- a/.github/workflows/snap-store-promote-to-stable.yml
+++ b/.github/workflows/snap-store-promote-to-stable.yml
@@ -38,10 +38,10 @@ jobs:
           revision=${arguments[0]}
           channel=${arguments[1]}
           
-          # Sanity checks
-          re='^[0-9]+$'
+          # Validation checks
+          re='^[0-9]+([,][0-9]+)*$'
           if [[ ! "$revision" =~ $re ]]; then
-            echo "revision must be a number, not '$revision'!"
+            echo "revision must be a number or a comma seperated list of numbers, not '$revision'!"
             exit 1
           fi
           if [[ "$channel" != "stable"  ]]; then
@@ -53,10 +53,16 @@ jobs:
           sudo snap install --classic snapcraft
           sudo chown root:root /
 
-          # Release
-          snapcraft release $SNAP_NAME "$revision" "$channel"
+          # Iterate over each specified revision and release
+          revs=$(echo $revision | tr "," "\n")
+          released_revs=()
+          
+          for r in $revs; do
+            snapcraft release $SNAP_NAME "$r" "$channel"
+            released_revs+="$r"
+          done
 
-          echo "revision=$revision" >> $GITHUB_OUTPUT
+          echo "revisions=${released_revs[@]}" >> $GITHUB_OUTPUT
           echo "channel=$channel" >> $GITHUB_OUTPUT
       - uses: actions/github-script@v6
         with:
@@ -65,7 +71,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Great, revision `${{ steps.promote.outputs.revision }}` version is now in `${{ steps.promote.outputs.channel }}`!'
+              body: 'The following revisions were released to the `${{ steps.promote.outputs.channel }}` channel: `${{ steps.promote.outputs.revisions }}`'
             })
             github.rest.issues.update({
               issue_number: context.issue.number,

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -57,15 +57,6 @@ jobs:
           
           version="$(cat snap/snapcraft.yaml | yq -r '.version')"
           echo "{snap}={signal_desktop_$version_${{ matrix.arch}}.snap}" >> "$GITHUB_OUTPUT"
-          echo "{log}={signal_desktop_$version_${{ matrix.arch}}.txt}" >> "$GITHUB_OUTPUT"
-
-      - name: Upload remote build snap artifacts and build logs
-        uses: actions/upload-artifact@v3
-        with:
-          name: remote-build-snaps
-          path: |
-            ${{ steps.build.outputs.snap }}
-            ${{ steps.build.outputs.log }}
 
       - name: Run the snapcraft review tools
         uses: diddlesnaps/snapcraft-review-action@v1

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -57,6 +57,15 @@ jobs:
           
           version="$(cat snap/snapcraft.yaml | yq -r '.version')"
           echo "{snap}={signal_desktop_$version_${{ matrix.arch}}.snap}" >> "$GITHUB_OUTPUT"
+          echo "{log}={signal_desktop_$version_${{ matrix.arch}}.txt}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload remote build snap artifacts and build logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: remote-build-snaps
+          path: |
+            ${{ steps.build.outputs.snap }}
+            ${{ steps.build.outputs.log }}
 
       - name: Run the snapcraft review tools
         uses: diddlesnaps/snapcraft-review-action@v1

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -11,6 +11,8 @@ on:
     secrets:
       SNAP_STORE_CANDIDATE:
         required: true
+      LP_BUILD_SECRET:
+        required: true
 
 # Permissions for GITHUB_TOKEN
 permissions:

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -28,9 +28,6 @@ jobs:
     name: "Build and publish snap"
     environment: "Candidate Branch"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: ["amd64", "arm64"]
     steps:
       - name: Checkout the source
         uses: actions/checkout@v3
@@ -53,23 +50,38 @@ jobs:
       - name: Remote build the snap
         id: build
         run : |
-          snapcraft remote-build --launchpad-accept-public-upload --build-for ${{ matrix.arch }}
+          snapcraft remote-build --launchpad-accept-public-upload
           
           version="$(cat snap/snapcraft.yaml | yq -r '.version')"
-          echo "{snap}={signal_desktop_$version_${{ matrix.arch}}.snap}" >> "$GITHUB_OUTPUT"
+          echo "{amd64_snap}={signal_desktop_$version_amd64.snap}" >> "$GITHUB_OUTPUT"
+          echo "{arm64_snap}={signal_desktop_$version_arm64.snap}" >> "$GITHUB_OUTPUT"
 
-      - name: Run the snapcraft review tools
+      - name: Review the built amd64 snap
         uses: diddlesnaps/snapcraft-review-action@v1
         with:
-          snap: ${{ steps.build.outputs.snap }}
+          snap: ${{ steps.build.outputs.amd64_snap }}
           isClassic: 'false'
-      
-      - name: Publish the snap
+
+      - name: Review the built arm64 snap
+        uses: diddlesnaps/snapcraft-review-action@v1
+        with:
+          snap: ${{ steps.build.outputs.arm64_snap }}
+          isClassic: 'false'
+
+      - name: Publish the amd64 snap
         uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
         with:
-          snap: ${{ steps.build.outputs.snap }}
+          snap: ${{ steps.build.outputs.amd64_snap }}
+          release: ${{ env.CHANNEL }}
+
+      - name: Publish the arm64 snap
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
+        with:
+          snap: ${{ steps.build.outputs.arm64_snap }}
           release: ${{ env.CHANNEL }}
           
   create_issue:

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -28,17 +28,44 @@ jobs:
     name: "Build and publish snap"
     environment: "Candidate Branch"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ["amd64", "arm64"]
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout the source
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.CHANNEL }}
-      - uses: snapcore/action-build@v1
+
+      - name: Setup snapcraft
+        env:
+          LP_BUILD_SECRET: ${{ secrets.LP_BUILD_SECRET }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
+        run: |
+          sudo snap install snapcraft --classic
+          
+          # Setup Launchpad credentials
+          mkdir -p ~/.local/share/snapcraft/provider/launchpad
+          echo "$LP_BUILD_SECRET" > ~/.local/share/snapcraft/provider/launchpad/credentials
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "Github Actions"
+
+      - name: Remote build the snap
         id: build
-      - uses: diddlesnaps/snapcraft-review-action@v1
+        run : |
+          snapcraft remote-build --launchpad-accept-public-upload --build-for ${{ matrix.arch }}
+          
+          version="$(cat snap/snapcraft.yaml | yq -r '.version')"
+          echo "{snap}={signal_desktop_$version_${{ matrix.arch}}.snap}" >> "$GITHUB_OUTPUT"
+
+      - name: Run the snapcraft review tools
+        uses: diddlesnaps/snapcraft-review-action@v1
         with:
           snap: ${{ steps.build.outputs.snap }}
           isClassic: 'false'
-      - uses: snapcore/action-publish@v1
+      
+      - name: Publish the snap
+        uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
         with:

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -24,6 +24,17 @@ jobs:
             jq .  | grep tag_name | grep -v beta | head -n 1 | cut -d'"' -f4 | tr -d 'v'
           )
           sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml
+
+          # Fetch the upstream package.json for the fetched version
+          wget -qO package.json https://raw.githubusercontent.com/signalapp/Signal-Desktop/v${VERSION}/package.json
+
+          # Update the @signalapp/ringrtc version if required
+          export RINGRTC_VERSION="$(cat package.json | jq -r '.dependencies."@signalapp/ringrtc"')"
+          sed -i -E "s|ringrtc-[0-9]+\.[0-9]+\.[0-9]+\.tgz|ringrtc-${RINGRTC_VERSION}.tgz|" snap/snapcraft.yaml
+
+          # Update the @signalapp/bettersqlite version if required
+          BETTERSQLITE_VERSION="$(cat package.json | jq -r '.dependencies."@signalapp/better-sqlite3"')"
+          sed -i -E "s|better-sqlite3-[0-9]+\.[0-9]+\.[0-9]+\.tgz|better-sqlite3-${BETTERSQLITE_VERSION}.tgz|" snap/snapcraft.yaml
       - name: Check for modified files
         id: git-check
         run: |

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,4 +1,4 @@
-name: 🧪 Test snap can be built
+name: 🧪 Test snap can be built on x86_64
 
 on:
   pull_request:
@@ -11,44 +11,16 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup snapcraft
-        env:
-          LP_BUILD_SECRET: ${{ secrets.LP_BUILD_SECRET }}
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
-        run: |
-          sudo snap install snapcraft --classic
-          
-          # Setup Launchpad credentials
-          mkdir -p ~/.local/share/snapcraft/provider/launchpad
-          echo "$LP_BUILD_SECRET" > ~/.local/share/snapcraft/provider/launchpad/credentials
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "Github Actions"
-
-      - name: Remote build the snap
+      - uses: snapcore/action-build@v1
         id: build
-        run : |
-          snapcraft remote-build --launchpad-accept-public-upload
-          
-          version="$(cat snap/snapcraft.yaml | yq -r '.version')"
-          echo "{amd64_snap}={signal_desktop_$version_amd64.snap}" >> "$GITHUB_OUTPUT"
-          echo "{arm64_snap}={signal_desktop_$version_arm64.snap}" >> "$GITHUB_OUTPUT"
 
-      - name: Review the built amd64 snap
-        uses: diddlesnaps/snapcraft-review-action@v1
+      - uses: diddlesnaps/snapcraft-review-action@v1
         with:
-          snap: ${{ steps.build.outputs.amd64_snap }}
-          isClassic: 'false'
-          # Plugs and Slots declarations to override default denial (requires store assertion to publish)
-          # plugs: ./plug-declaration.json
-          # slots: ./slot-declaration.json
-
-      - name: Review the built arm64 snap
-        uses: diddlesnaps/snapcraft-review-action@v1
-        with:
-          snap: ${{ steps.build.outputs.arm64_snap }}
+          snap: ${{ steps.build.outputs.snap }}
           isClassic: 'false'
           # Plugs and Slots declarations to override default denial (requires store assertion to publish)
           # plugs: ./plug-declaration.json

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -11,12 +11,33 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ["amd64", "arm64"]
 
     steps:
       - uses: actions/checkout@v3
 
-      - uses: snapcore/action-build@v1
+      - name: Setup snapcraft
+        env:
+          LP_BUILD_SECRET: ${{ secrets.LP_BUILD_SECRET }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
+        run: |
+          sudo snap install snapcraft --classic
+          
+          # Setup Launchpad credentials
+          mkdir -p ~/.local/share/snapcraft/provider/launchpad
+          echo "$LP_BUILD_SECRET" > ~/.local/share/snapcraft/provider/launchpad/credentials
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "Github Actions"
+
+      - name: Remote build the snap
         id: build
+        run : |
+          snapcraft remote-build --launchpad-accept-public-upload --build-for ${{ matrix.arch }}
+          
+          version="$(cat snap/snapcraft.yaml | yq -r '.version')"
+          echo "{snap}={signal_desktop_$version_${{ matrix.arch}}.snap}" >> "$GITHUB_OUTPUT"
 
       - uses: diddlesnaps/snapcraft-review-action@v1
         with:

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,4 +1,4 @@
-name: 🧪 Test snap can be built on x86_64
+name: 🧪 Test snap can be built
 
 on:
   pull_request:
@@ -11,10 +11,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: ["amd64", "arm64"]
-
     steps:
       - uses: actions/checkout@v3
 
@@ -34,14 +30,25 @@ jobs:
       - name: Remote build the snap
         id: build
         run : |
-          snapcraft remote-build --launchpad-accept-public-upload --build-for ${{ matrix.arch }}
+          snapcraft remote-build --launchpad-accept-public-upload
           
           version="$(cat snap/snapcraft.yaml | yq -r '.version')"
-          echo "{snap}={signal_desktop_$version_${{ matrix.arch}}.snap}" >> "$GITHUB_OUTPUT"
+          echo "{amd64_snap}={signal_desktop_$version_amd64.snap}" >> "$GITHUB_OUTPUT"
+          echo "{arm64_snap}={signal_desktop_$version_arm64.snap}" >> "$GITHUB_OUTPUT"
 
-      - uses: diddlesnaps/snapcraft-review-action@v1
+      - name: Review the built amd64 snap
+        uses: diddlesnaps/snapcraft-review-action@v1
         with:
-          snap: ${{ steps.build.outputs.snap }}
+          snap: ${{ steps.build.outputs.amd64_snap }}
+          isClassic: 'false'
+          # Plugs and Slots declarations to override default denial (requires store assertion to publish)
+          # plugs: ./plug-declaration.json
+          # slots: ./slot-declaration.json
+
+      - name: Review the built arm64 snap
+        uses: diddlesnaps/snapcraft-review-action@v1
+        with:
+          snap: ${{ steps.build.outputs.arm64_snap }}
           isClassic: 'false'
           # Plugs and Slots declarations to override default denial (requires store assertion to publish)
           # plugs: ./plug-declaration.json


### PR DESCRIPTION
Fixes #180. This PR is dependent on #179 and should be merged after.

Because we now have multiple parts, which are dependent on the version of Signal, we need to augment the CI to ensure that when we bump the Signal version, we also bump the parts versions if required.

This PR also switches the build process to using `snapcraft remote-build` in a matrix that creates a job per architecture.

This will be hard to review until #179 is merged, but the diff can be seen cleanly here: https://github.com/snapcrafters/signal-desktop/commit/7eb0bffd90d2efbe609283e47e6504a493fea9b7