### PR TITLE
ci: only bump parts if signal-desktop version changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -25,16 +25,19 @@ jobs:
           )
           sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml
 
-          # Fetch the upstream package.json for the fetched version
-          wget -qO package.json https://raw.githubusercontent.com/signalapp/Signal-Desktop/v${VERSION}/package.json
+          # If the signal-desktop version has changed, bump the dependencies.
+          if ! git diff --quiet --exit-code; then
+            # Fetch the upstream package.json for the fetched version
+            wget -qO package.json https://raw.githubusercontent.com/signalapp/Signal-Desktop/v${VERSION}/package.json
 
-          # Update the @signalapp/ringrtc version if required
-          export RINGRTC_VERSION="$(cat package.json | jq -r '.dependencies."@signalapp/ringrtc"')"
-          sed -i -E "s|ringrtc-[0-9]+\.[0-9]+\.[0-9]+\.tgz|ringrtc-${RINGRTC_VERSION}.tgz|" snap/snapcraft.yaml
+            # Update the @signalapp/ringrtc version if required
+            export RINGRTC_VERSION="$(cat package.json | jq -r '.dependencies."@signalapp/ringrtc"')"
+            sed -i -E "s|ringrtc-[0-9]+\.[0-9]+\.[0-9]+\.tgz|ringrtc-${RINGRTC_VERSION}.tgz|" snap/snapcraft.yaml
 
-          # Update the @signalapp/bettersqlite version if required
-          BETTERSQLITE_VERSION="$(cat package.json | jq -r '.dependencies."@signalapp/better-sqlite3"')"
-          sed -i -E "s|better-sqlite3-[0-9]+\.[0-9]+\.[0-9]+\.tgz|better-sqlite3-${BETTERSQLITE_VERSION}.tgz|" snap/snapcraft.yaml
+            # Update the @signalapp/bettersqlite version if required
+            BETTERSQLITE_VERSION="$(cat package.json | jq -r '.dependencies."@signalapp/better-sqlite3"')"
+            sed -i -E "s|better-sqlite3-[0-9]+\.[0-9]+\.[0-9]+\.tgz|better-sqlite3-${BETTERSQLITE_VERSION}.tgz|" snap/snapcraft.yaml
+          fi
       - name: Check for modified files
         id: git-check
         run: |

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -37,6 +37,8 @@ jobs:
             # Update the @signalapp/bettersqlite version if required
             BETTERSQLITE_VERSION="$(cat package.json | jq -r '.dependencies."@signalapp/better-sqlite3"')"
             sed -i -E "s|better-sqlite3-[0-9]+\.[0-9]+\.[0-9]+\.tgz|better-sqlite3-${BETTERSQLITE_VERSION}.tgz|" snap/snapcraft.yaml
+
+            rm package.json
           fi
       - name: Check for modified files
         id: git-check


### PR DESCRIPTION
This change introduces a guard on the logic that bumps the dependency versions, currently bought in as `parts`.

The change adds an `if` statement to check if there are any changes after we try to manipulate the `snapcraft.yaml` version to match the upstream. If there are changes in the tree, we also look to update the parts, otherwise we just move on.