### PR TITLE
feat: add snap config item for tray-icon; disable by default

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# On Fedora $SNAP is under /var and there is some magic to map it to /snap.
+# We need to handle that case and reset $SNAP
+SNAP="${SNAP//\/var\/lib\/snapd/}"
+
+tray_icon="$(snapctl get tray-icon)"
+if [[ -z "$tray_icon" ]]; then
+    snapctl set tray-icon=false
+fi

--- a/snap/local/usr/bin/signal-desktop-wrapper
+++ b/snap/local/usr/bin/signal-desktop-wrapper
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the configure hook which sets defaults for any config options
+"${SNAP}/snap/hooks/configure"
+
+# Grab the config options
+tray_icon="$(snapctl get tray-icon)"
+
+# Define an array of command line options
+opts=()
+
+# If the the tray icon is enabled, add to the list of command line args
+if [[ "${tray_icon}" == "true" ]]; then
+    opts+=("--use-tray-icon")
+fi
+
+# Run signal-desktop with the gathered arguments
+exec "${SNAP}/opt/Signal/signal-desktop" "--no-sandbox" "${opts[@]}"

--- a/snap/local/usr/bin/signal-desktop-wrapper
+++ b/snap/local/usr/bin/signal-desktop-wrapper
@@ -16,4 +16,4 @@ if [[ "${tray_icon}" == "true" ]]; then
 fi
 
 # Run signal-desktop with the gathered arguments
-exec "${SNAP}/opt/Signal/signal-desktop" "--no-sandbox" "${opts[@]}"
+exec "${SNAP}/opt/Signal/signal-desktop" "--no-sandbox" "${opts[@]}" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -203,6 +203,11 @@ parts:
       - -opt/Signal/resources/app.asar.unpacked/node_modules/sharp/vendor/lib
       - -opt/Signal/resources/app.asar.unpacked/node_modules/sharp/vendor/include
 
+  local-parts:
+    plugin: dump
+    source: ./snap/local
+    source-type: local
+
   cleanup:
     after: [signal-desktop]
     plugin: nil
@@ -219,7 +224,7 @@ parts:
 apps:
   signal-desktop:
     extensions: [gnome]
-    command: opt/Signal/signal-desktop --use-tray-icon --no-sandbox
+    command: usr/bin/signal-desktop-wrapper
     plugs:
       - browser-support
       - camera


### PR DESCRIPTION
This PR introduces a new snap configuration option `tray-icon`. When `tray-icon` is set to `true`, the `signal-desktop` binary is launched with the `--use-tray-icon` flag. 

The option is set to `false` by default.

Fixes https://github.com/snapcrafters/signal-desktop/issues/143
Fixes https://github.com/snapcrafters/signal-desktop/issues/153
Related: https://github.com/snapcrafters/signal-desktop/issues/195