### PR TITLE
ci: install signal in desktop vm and take screenshots

### DIFF
--- a/.github/testing-issue-template.md
+++ b/.github/testing-issue-template.md
@@ -10,7 +10,11 @@ A new version ({{ env.version }}) of `{{ env.SNAP_NAME }}` was just pushed to th
 | amd64            | {{ env.revision_amd64 }} |
 | arm64            | {{ env.revision_arm64 }} |
 
-## How to test it
+## Automated screenshots
+
+The snap will be installed in a VM automatically; screenshots will be posted as a comment on this issue shortly.
+
+## How to test it manually
 
 1. Stop the application if it was already running
 1. Upgrade to this version by running
@@ -32,6 +36,12 @@ Maintainers can promote this to stable by commenting `/promote <rev>[,<rev>] sta
 
 > For example
 >
-> * To promote a single revision, run `/promote <rev> stable`
-> * To promote multiple revisions, run `/promote <rev>,<rev> stable`
-> * To promote a revision and close the issue, run `/promote <rev>,<rev> stable done`
+> - To promote a single revision, run `/promote <rev> stable`
+> - To promote multiple revisions, run `/promote <rev>,<rev> stable`
+> - To promote a revision and close the issue, run `/promote <rev>,<rev> stable done`
+
+You can promote both revisions just built with:
+
+```
+/promote {{ env.revision_amd64 }},{{ env.revision_arm64 }} stable done
+```

--- a/.github/vmctl
+++ b/.github/vmctl
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Default VM attributes - tuned for Github Actions runners by default
+VM_NAME="${VM_NAME:-test-vm}"
+VM_SERIES="${VM_SERIES:-22.04}"
+VM_CPUS="${VM_CPUS:=1}"
+VM_MEM_GIB="${VM_MEM_GIB:=6}"
+VM_DISK_GIB="${VM_DISK_GIB:=12}"
+
+build_runner_script() {
+  vmctl_runner="$(mktemp)"
+  chmod +x "$vmctl_runner"
+  cat <<-EOF > "$vmctl_runner"
+#!/usr/bin/env bash
+
+export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
+export WAYLAND_DISPLAY=wayland-0
+export DISPLAY=:0.0
+export HOME=/home/ubuntu
+
+exec "\$@"
+EOF
+
+  echo "$vmctl_runner"
+}
+
+# If we're on a Github Actions Runner, enable KVM.
+enable_kvm_gha() {
+  if [[ -x "${GITHUB_ACTIONS:-}" ]]; then
+    echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger --name-match=kvm
+  fi
+}
+
+# Starts a desktop VM and waits for the agent to be running inside.
+prepare_vm() {
+  # Start the VM
+  lxc launch "images:ubuntu/${VM_SERIES}/desktop" "${VM_NAME}" --vm \
+    -c limits.cpu="${VM_CPUS}" -c limits.memory="${VM_MEM_GIB}GiB" -d root,size="${VM_DISK_GIB}GiB"
+
+  # Wait for the VM agent to be running
+  while ! lxc exec test-vm -- cat /etc/hostname &>/dev/null; do 
+    sleep 2
+  done
+
+  # Push script runner into the VM
+  lxc file push "$(build_runner_script)" test-vm/bin/vmctl-runner
+  lxc exec test-vm -- chmod 755 /bin/vmctl-runner
+
+  # Install gnome-screenshot
+  lxc exec test-vm -- apt-get update
+  lxc exec test-vm -- apt-get install -y gnome-screenshot
+
+  # Kill the gnome initial setup wizard
+  pid="$(lxc exec test-vm -- pidof gnome-initial-setup)"
+  lxc exec test-vm -- kill -9 "$pid"
+}
+
+# Exec a command in the VM using the wrapper.
+exec_in_vm() {
+  lxc exec test-vm -- sudo -u ubuntu bash -c "/bin/vmctl-runner $@"
+}
+
+# Uploads the specified file to imgur and prints the URL to the image
+upload_screenshot() {
+  curl -s -X POST -F "image=@${1}" https://api.imgur.com/3/upload | jq -r '.data.link'
+}
+
+# Takes a screenshot of the full screen and pulls the file back from the VM to a file
+# named "screenshot-screen.png", and uploads to imgur, returning the URL
+screenshot_full() {
+  # Take a screenshot of the whole screen in the VM
+  exec_in_vm "gnome-screenshot -f /home/ubuntu/screen.png"
+  # Pull the screenshot back to the host
+  lxc file pull test-vm/home/ubuntu/screen.png screenshot-screen.png
+  # Upload the screenshot to imgur and output the URL
+  upload_screenshot screenshot-screen.png
+}
+
+# Takes a screenshot of the active window and pulls the file back from the VM to a file
+# named "screenshot-window.png", and uploads to imgur, returning the URL
+screenshot_window() {
+  # Take a screenshot of the active window in the VM
+  exec_in_vm "gnome-screenshot -w -f /home/ubuntu/window.png"
+  # Pull the screenshot back to the host
+  lxc file pull test-vm/home/ubuntu/window.png screenshot-window.png
+  # Upload the screenshot to imgur and output the URL
+  upload_screenshot screenshot-window.png
+}
+
+# Print the usage statement and exit the program
+usage() {
+  echo "Usage: vmctl [prepare | push-snap <file> | exec <string> | screenshot-full | screenshot-window"]
+  exit 1
+}
+
+# Parse the subcommand and exit if empty, printing the usage
+command="${1:-}"; shift
+if [[ -z "$command" ]]; then
+  usage
+fi
+
+case "$command" in
+  "prepare")
+    enable_kvm_gha
+    prepare_vm
+    ;;
+  "exec")
+    exec_in_vm "$@"
+    ;;
+  "screenshot-full")
+    screenshot_full
+    ;;
+  "screenshot-window")
+    screenshot_window
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -33,6 +33,10 @@ jobs:
     strategy:
       matrix:
         architecture: ['amd64', 'arm64']
+    outputs:
+      revision_amd64: ${{ steps.publish.outputs.revision_amd64 }}
+      revision_arm64: ${{ steps.publish.outputs.revision_arm64 }}
+      version: ${{ steps.build.outputs.version }}
     steps:
       - name: Checkout the source
         uses: actions/checkout@v4
@@ -78,10 +82,9 @@ jobs:
         run: |
           rev=$(snapcraft push $SNAP_NAME --release=$CHANNEL)
           echo "revision_${ARCHITECTURE}=${rev}" >> $GITHUB_OUTPUT
-    outputs: 
-      revision_amd64: ${{ steps.publish.outputs.revision_amd64 }}
-      revision_arm64: ${{ steps.publish.outputs.revision_arm64 }}
-      version: ${{ steps.build.outputs.version }}
+
+  # Create an issue using the template that asks maintainers to test the snap, and take
+  # action to promote the revisions to stable if testing is successful.
   create_issue:
     name: "Create call for testing"
     needs: build
@@ -89,6 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: JasonEtco/create-an-issue@v2
+        id: comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           revision_amd64: ${{ needs.build.outputs.revision_amd64 }}
@@ -96,3 +100,55 @@ jobs:
           version: ${{ needs.build.outputs.version }}
         with:
           filename: .github/testing-issue-template.md
+    outputs:
+      issue_number: ${{ steps.comment.outputs.number }}
+
+  # Deploy the snap inside a desktop VM and grab screenshots of the desktop, and of
+  # the application, then post them as a comment on the issue created above.
+  grab-screenshots:
+    name: Gather screenshots
+    needs: 
+      - build
+      - create_issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+
+      - name: Setup test machine and start Signal
+        id: screenshots
+        run: |
+          .github/vmctl prepare
+          .github/vmctl exec "sudo snap install ${{ env.SNAP_NAME }} --revision ${{ needs.build.outputs.revision_amd64 }}"
+          .github/vmctl exec "snap run signal-desktop &>/home/ubuntu/signal.log &"
+          sleep 20
+
+          screenshot_full="$(.github/vmctl screenshot-full)"
+          echo "screen=$screenshot_full" >> "$GITHUB_OUTPUT"
+          echo "Screenshot of full screen at: $screen"
+
+          screenshot_window="$(.github/vmctl screenshot-window)"
+          echo "window=$screenshot_window" >> "$GITHUB_OUTPUT"
+          echo "Screenshot of window at: $window"
+
+          # Output the Signal logs captured from stdout/stderr (for debgging if required)
+          .github/vmctl exec "cat /home/ubuntu/signal.log"
+
+      - name: Comment on call for testing issue with screenshots
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: ${{ needs.create_issue.outputs.issue_number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `The following screenshots were taken during automated testing:
+
+              ![window](${{ steps.screenshots.outputs.window }})
+
+              ![screen](${{ steps.screenshots.outputs.screen }})
+              `
+            })

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -127,12 +127,12 @@ jobs:
           sleep 20
 
           screenshot_full="$(.github/vmctl screenshot-full)"
+          echo "Screenshot of full screen at: $screenshot_screen"
           echo "screen=$screenshot_full" >> "$GITHUB_OUTPUT"
-          echo "Screenshot of full screen at: $screen"
 
           screenshot_window="$(.github/vmctl screenshot-window)"
+          echo "Screenshot of window at: $screenshot_window"
           echo "window=$screenshot_window" >> "$GITHUB_OUTPUT"
-          echo "Screenshot of window at: $window"
 
           # Output the Signal logs captured from stdout/stderr (for debgging if required)
           .github/vmctl exec "cat /home/ubuntu/signal.log"

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - uses: snapcore/action-build@v1
+      - name: Build snap
+        uses: snapcore/action-build@v1
         id: build
 
-      - uses: diddlesnaps/snapcraft-review-action@v1
+      - name: Review snap
+        uses: diddlesnaps/snapcraft-review-action@v1
         with:
           snap: ${{ steps.build.outputs.snap }}
           isClassic: 'false'
-          # Plugs and Slots declarations to override default denial (requires store assertion to publish)
-          # plugs: ./plug-declaration.json
-          # slots: ./slot-declaration.json

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ stage/
 
 # Debug
 squashfs-root
+
+# The .github/vmctl script fetches screenshots from a running vm, using these
+# filenames by default.
+screenshot-screen.png
+screenshot-window.png

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Now that your git metadata has been updated you are ready to create a bugfix bra
 ## Maintainers
 
 * [@merlijn-sebrechts](https://github.com/merlijn-sebrechts/)
+* [@jnsgruk](https://github.com/jnsgruk/)
 
 ## License
 


### PR DESCRIPTION
This is a test that adds the ability to launch a KVM accelerated desktop VM inside the Github Actions runner.

Once running, we push the built snap into the VM and run signal-desktop. From there, we can use `gnome-screenshot` to get a screenshot of both the whole screen and the specific window we just launched.

Then finish by pulling the screenshot files out of the VM and adding them in a comment on the call for testing post.