### PR TITLE
ci: fix revision parsing on candidate release flow

### DIFF
--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -76,7 +76,8 @@ jobs:
           SNAP_NAME: ${{ steps.build.outputs.snap }}
           ARCHITECTURE: ${{ matrix.architecture }}
         run: |
-          rev=$(snapcraft push $SNAP_NAME --release=$CHANNEL)
+          snapcraft_out="$(snapcraft push "$SNAP_NAME" --release="$CHANNEL")"
+          rev="$(echo "$snapcraft_out" | grep -Po 'Revision \K[^ ]+')"
           echo "revision_${ARCHITECTURE}=${rev}" >> $GITHUB_OUTPUT
     outputs: 
       revision_amd64: ${{ steps.publish.outputs.revision_amd64 }}


### PR DESCRIPTION
Fixes the current issue where the revision numbers of newly uploaded builds to the `candidate` channel are not correctly parsed.

This fix does the following - take for example:

```
$ snapcraft push signal-desktop --release=candidate
Revision 564 created for 'signal-desktop' and released to 'candidate'

$ echo "Revision 564 created for 'signal-desktop' and released to 'candidate'" | grep -Po 'Revision \K[^ ]+'
564
```