### PR TITLE
ci: upload screenshots to a seperate repo

### DIFF
--- a/.github/vmctl
+++ b/.github/vmctl
@@ -63,11 +63,6 @@ exec_in_vm() {
   lxc exec test-vm -- sudo -u ubuntu bash -c "/bin/vmctl-runner $@"
 }
 
-# Uploads the specified file to imgur and prints the URL to the image
-upload_screenshot() {
-  curl -s -X POST -F "image=@${1}" https://api.imgur.com/3/upload | jq -r '.data.link'
-}
-
 # Takes a screenshot of the full screen and pulls the file back from the VM to a file
 # named "screenshot-screen.png", and uploads to imgur, returning the URL
 screenshot_full() {
@@ -75,8 +70,6 @@ screenshot_full() {
   exec_in_vm "gnome-screenshot -f /home/ubuntu/screen.png"
   # Pull the screenshot back to the host
   lxc file pull test-vm/home/ubuntu/screen.png screenshot-screen.png
-  # Upload the screenshot to imgur and output the URL
-  upload_screenshot screenshot-screen.png
 }
 
 # Takes a screenshot of the active window and pulls the file back from the VM to a file
@@ -86,8 +79,6 @@ screenshot_window() {
   exec_in_vm "gnome-screenshot -w -f /home/ubuntu/window.png"
   # Pull the screenshot back to the host
   lxc file pull test-vm/home/ubuntu/window.png screenshot-window.png
-  # Upload the screenshot to imgur and output the URL
-  upload_screenshot screenshot-window.png
 }
 
 # Print the usage statement and exit the program

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -67,7 +67,7 @@ jobs:
 
           version="$(cat snap/snapcraft.yaml | yq -r '.version')"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "snap=signal-desktop_${version}_${ARCHITECTURE}.snap" >> "$GITHUB_OUTPUT"
+          echo "snap=${{ env.SNAP_NAME }}_${version}_${ARCHITECTURE}.snap" >> "$GITHUB_OUTPUT"
 
       - name: Review the built snap
         uses: diddlesnaps/snapcraft-review-action@v1
@@ -125,7 +125,7 @@ jobs:
         run: |
           .github/vmctl prepare
           .github/vmctl exec "sudo snap install ${{ env.SNAP_NAME }} --revision ${{ needs.build.outputs.revision_amd64 }}"
-          .github/vmctl exec "snap run signal-desktop &>/home/ubuntu/signal.log &"
+          .github/vmctl exec "snap run ${{ env.SNAP_NAME }} &>/home/ubuntu/${{ env.SNAP_NAME }}.log &"
           sleep 20
 
       - name: Gather screenshots
@@ -135,7 +135,7 @@ jobs:
 
       - name: Output application logs
         run: |
-          .github/vmctl exec "cat /home/ubuntu/signal.log"
+          .github/vmctl exec "cat /home/ubuntu/${{ env.SNAP_NAME }}.log"
 
       - name: Checkout snapcrafters/ci-screenshots
         uses: actions/checkout@v4

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -13,6 +13,8 @@ on:
         required: true
       LP_BUILD_SECRET:
         required: true
+      SNAPCRAFTERS_BOT_COMMIT:
+        required: true
 
 # Permissions for GITHUB_TOKEN
 permissions:
@@ -119,24 +121,47 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@v0.1.1
 
-      - name: Setup test machine and start Signal
-        id: screenshots
+      - name: Prepare VM
         run: |
           .github/vmctl prepare
           .github/vmctl exec "sudo snap install ${{ env.SNAP_NAME }} --revision ${{ needs.build.outputs.revision_amd64 }}"
           .github/vmctl exec "snap run signal-desktop &>/home/ubuntu/signal.log &"
           sleep 20
 
-          screenshot_full="$(.github/vmctl screenshot-full)"
-          echo "Screenshot of full screen at: $screenshot_screen"
-          echo "screen=$screenshot_full" >> "$GITHUB_OUTPUT"
+      - name: Gather screenshots
+        run: |
+          .github/vmctl screenshot-full
+          .github/vmctl screenshot-window
 
-          screenshot_window="$(.github/vmctl screenshot-window)"
-          echo "Screenshot of window at: $screenshot_window"
-          echo "window=$screenshot_window" >> "$GITHUB_OUTPUT"
-
-          # Output the Signal logs captured from stdout/stderr (for debgging if required)
+      - name: Output application logs
+        run: |
           .github/vmctl exec "cat /home/ubuntu/signal.log"
+
+      - name: Checkout snapcrafters/ci-screenshots
+        uses: actions/checkout@v4
+        with: 
+          repository: snapcrafters/ci-screenshots
+          path: ci-screenshots
+          token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
+
+      - name: Upload screenshots to snapcrafters/ci-screenshots
+        id: screenshots
+        run: |
+          file_prefix="$(date +%Y%m%d)-${{ env.SNAP_NAME }}-${{ needs.create_issue.outputs.issue_number }}"
+
+          pushd ci-screenshots
+          mv ../screenshot-screen.png "${file_prefix}-screen.png"
+          mv ../screenshot-window.png "${file_prefix}-window.png"
+
+          git config --global user.email "merlijn.sebrechts+snapcrafters-bot@gmail.com"
+          git config --global user.name "Snapcrafters Bot"
+
+          git add -A .
+          git commit -m "data: screenshots for snapcrafters/${{ env.SNAP_NAME }}#${{ needs.create_issue.outputs.issue_number }}"
+          git push origin main
+
+          echo "screen=https://raw.githubusercontent.com/snapcrafters/ci-screenshots/main/${file_prefix}-screen.png" >> "$GITHUB_OUTPUT"
+          echo "window=https://raw.githubusercontent.com/snapcrafters/ci-screenshots/main/${file_prefix}-window.png" >> "$GITHUB_OUTPUT"
 
       - name: Comment on call for testing issue with screenshots
         uses: actions/github-script@v7


### PR DESCRIPTION
This PR removes reliance on Imgur, and instead uploads the grabbed screenshots to a separate repo `snapcrafters/ci-screenshots`.

I've also broken the screenshot CI into smaller stages as it's a little easier to debug this way.

Working run on my fork can be seen [here](https://github.com/jnsgruk/signal-desktop/issues/9) and the corresponding commit on a forked [screenshots repo](https://github.com/jnsgruk/ci-screenshots/commit/031dbdc23e2c8537e707e40b074755f7928edc09).