### PR TITLE
ci: consolidate stage outputs and build rev/arch table

### DIFF
--- a/.github/testing-issue-template.md
+++ b/.github/testing-issue-template.md
@@ -5,10 +5,7 @@ labels: testing
 
 A new version ({{ env.version }}) of `{{ env.SNAP_NAME }}` was just pushed to the `{{ env.CHANNEL }}` channel [in the snap store](https://snapcraft.io/{{ env.SNAP_NAME }}). The following revisions are available.
 
-| CPU architecture | Revision                 |
-|------------------|--------------------------|
-| amd64            | {{ env.revision_amd64 }} |
-| arm64            | {{ env.revision_arm64 }} |
+{{ env.table }}
 
 ## Automated screenshots
 
@@ -40,8 +37,8 @@ Maintainers can promote this to stable by commenting `/promote <rev>[,<rev>] sta
 > - To promote multiple revisions, run `/promote <rev>,<rev> stable`
 > - To promote a revision and close the issue, run `/promote <rev>,<rev> stable done`
 
-You can promote both revisions just built with:
+You can promote all revisions that were just built with:
 
 ```
-/promote {{ env.revision_amd64 }},{{ env.revision_arm64 }} stable done
+/promote {{ env.revisions }} stable done
 ```

--- a/.github/workflows/snap-store-promote-to-stable.yml
+++ b/.github/workflows/snap-store-promote-to-stable.yml
@@ -64,7 +64,7 @@ jobs:
 
           for r in $revs; do
             snapcraft release $SNAP_NAME "$r" "$channel"
-            released_revs+="$r"
+            released_revs+=("$r")
           done
 
           echo "revisions=${released_revs[@]}" >> $GITHUB_OUTPUT

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -42,8 +42,14 @@ jobs:
       - name: Compute architectures
         id: archs
         run: |
-          # Grab the architecture list as a JSON array
-          archs="$(cat snap/snapcraft.yaml | yq -I=0 -o=json '[.architectures[]."build-on"]')"
+          # Handle the case where architectures is a simple list of strings
+          archs="$(cat snap/snapcraft.yaml | yq -I=0 -o=json '[.architectures[]]')"
+
+          # Handle the case where architectures is a list of objects
+          if echo "$archs" | grep -q "build-on"; then
+              archs="$(cat snap/snapcraft.yaml | yq -I=0 -o=json '[.architectures[]."build-on"]')"
+          fi
+
           echo "archs=$archs" >> "$GITHUB_OUTPUT"
 
   build:
@@ -56,8 +62,6 @@ jobs:
         # Parse the list of architectures from the output we created above (one job per arch)
         architecture: ${{ fromJSON(needs.get_archs.outputs.archs) }}
     outputs:
-      revision_amd64: ${{ steps.publish.outputs.revision_amd64 }}
-      revision_arm64: ${{ steps.publish.outputs.revision_arm64 }}
       version: ${{ steps.build.outputs.version }}
     steps:
       - name: Checkout the source
@@ -68,7 +72,6 @@ jobs:
       - name: Setup snapcraft
         env:
           LP_BUILD_SECRET: ${{ secrets.LP_BUILD_SECRET }}
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
         run: |
           sudo snap install snapcraft --classic
 
@@ -106,27 +109,61 @@ jobs:
         id: publish
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
-          SNAP_NAME: ${{ steps.build.outputs.snap }}
+          SNAP_FILE: ${{ steps.build.outputs.snap }}
           ARCHITECTURE: ${{ matrix.architecture }}
         run: |
-          snapcraft_out="$(snapcraft push "$SNAP_NAME" --release="$CHANNEL")"
-          rev="$(echo "$snapcraft_out" | grep -Po 'Revision \K[^ ]+')"
-          echo "revision_${ARCHITECTURE}=${rev}" >> $GITHUB_OUTPUT
+          snapcraft push "$SNAP_FILE" --release="$CHANNEL"
 
   # Create an issue using the template that asks maintainers to test the snap, and take
   # action to promote the revisions to stable if testing is successful.
   create_issue:
     name: "Create call for testing"
+    environment: "Candidate Branch"
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: JasonEtco/create-an-issue@v2
+      - name: Checkout the source
+        uses: actions/checkout@v4
+      
+      - name: Setup snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+
+      - name: Write the arch/rev table
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
+        id: build
+        run: |
+          # Build the initial structure for the HTML table including the header row.
+          table="<table><thead><tr><th>CPU Architecture</th><th>Revision</th></tr></thead><tbody>"
+
+          # Declare an array to keep track of the revisions we've seen
+          revisions=()
+
+          # Iterate over the architectures specified in the snapcraft.yaml
+          for arch in $(cat snap/snapcraft.yaml | yq '.architectures[]'); do
+              rev="$(snapcraft list-revisions "${{ env.SNAP_NAME }}" --arch "$arch" | grep "latest/candidate*" | head -n1 | cut -d' ' -f1)"
+              revisions+=("$rev")
+              # Add a row to the HTML table
+              table="${table}<tr><td>${arch}</td><td>${rev}</td></tr>"
+          done
+
+          # Add the closing tags for the table
+          table="${table}</tbody></table>"
+
+          # Get a comma separated list of revisions
+          printf -v joined '%s,' "${revisions[@]}"
+
+          echo "revisions=${joined%,}" >> "$GITHUB_OUTPUT"
+          echo "table=${table}" >> "$GITHUB_OUTPUT"
+
+      - name: Create call for testing issue
+        uses: JasonEtco/create-an-issue@v2
         id: comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          revision_amd64: ${{ needs.build.outputs.revision_amd64 }}
-          revision_arm64: ${{ needs.build.outputs.revision_arm64 }}
+          revisions: ${{ steps.build.outputs.revisions }}
+          table: ${{ steps.build.outputs.table }}
           version: ${{ needs.build.outputs.version }}
         with:
           filename: .github/testing-issue-template.md
@@ -152,7 +189,7 @@ jobs:
       - name: Prepare VM
         run: |
           .github/vmctl prepare
-          .github/vmctl exec "sudo snap install ${{ env.SNAP_NAME }} --revision ${{ needs.build.outputs.revision_amd64 }}"
+          .github/vmctl exec "sudo snap install ${{ env.SNAP_NAME }} --channel candidate"
           .github/vmctl exec "snap run ${{ env.SNAP_NAME }} &>/home/ubuntu/${{ env.SNAP_NAME }}.log &"
           sleep 20
 

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -16,6 +16,10 @@ on:
       SNAPCRAFTERS_BOT_COMMIT:
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Permissions for GITHUB_TOKEN
 permissions:
   contents: read

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ "**" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Permissions for GITHUB_TOKEN
 permissions:
   contents: read

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,8 +43,8 @@ confinement: strict
 compression: lzo
 
 architectures:
-  - build-on: amd64
-  - build-on: arm64
+  - amd64
+  - arm64
 
 parts:
   # NodeJS dependency which uses a non-proxy aware fetch during its build.


### PR DESCRIPTION
This change makes some changes to how we track the revisions that have been uploaded from stage to stage.

We cannot easily have multiple matrix outputs, which appears to be a known and common issue. This solution relies instead upon simply querying the store for the latest revision of a given architecture in the candidate channel, and using that.

The template has been adjusted to take a single "table" variable, which is a dynamically built HTML table that has a row for each supported architecture -- markdown tables cannot be used here because of how the template engine (mustache) renders '\n'.

There is a very small chance of a race condition if two PRs are merged in quick succession that we could get incorrect rev numbers, but I think that's mitigated by the concurrency controls which mean that only once instance can run at a given time.

This commit includes some drivebys to tidy up existing names and make things easier to reason about.