### PR TITLE
feat: native wayland support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ snap install signal-desktop
 
 | option       | default | description  |
 |--------------|---------|--------------|
-| tray-icon    | false   | Whether or not to use the system tray (minimize to tray) support. This is disabled by default per the request of the Signal developers, because system tray support is not stable. Set to `false`, Signal will stop when you close it and will not have a system tray icon. Set to `true`, Signal will minimize to tray wen you close it, and will have a system tray icon on supported desktops. |
+| `tray-icon`    | `false`   | Whether or not to use the system tray (minimize to tray) support. This is disabled by default per the request of the Signal developers, because system tray support is not stable. Set to `false`, Signal will stop when you close it and will not have a system tray icon. Set to `true`, Signal will minimize to tray wen you close it, and will have a system tray icon on supported desktops. |
+| `wayland-native`    | `false`   | When `true`, this config option forces the Signal Desktop app to start using the Ozone patches to Electron, which means the application can run natively on Wayland in supported setups. |
 
 You can change Snap configuration by running `snap set signal-desktop <key>=<value>`. For example, `snap set signal-desktop tray-icon=true`.
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -9,3 +9,8 @@ tray_icon="$(snapctl get tray-icon)"
 if [[ -z "$tray_icon" ]]; then
     snapctl set tray-icon=false
 fi
+
+wayland_native="$(snapctl get wayland-native)"
+if [[ -z "$wayland_native" ]]; then
+    snapctl set wayland-native=false
+fi

--- a/snap/local/usr/bin/signal-desktop-wrapper
+++ b/snap/local/usr/bin/signal-desktop-wrapper
@@ -6,6 +6,7 @@ set -euo pipefail
 
 # Grab the config options
 tray_icon="$(snapctl get tray-icon)"
+wayland_native="$(snapctl get wayland-native)"
 
 # Define an array of command line options
 opts=()
@@ -13,6 +14,14 @@ opts=()
 # If the the tray icon is enabled, add to the list of command line args
 if [[ "${tray_icon}" == "true" ]]; then
     opts+=("--use-tray-icon")
+fi
+
+if [[ "${wayland_native}" == "true" ]]; then
+    opts+=(
+        "--enable-features=UseOzonePlatform"
+        "--enable-features=WaylandWindowDecorations"
+        "--ozone-platform=wayland"
+    )
 fi
 
 # Run signal-desktop with the gathered arguments

--- a/snap/local/usr/bin/signal-desktop-wrapper
+++ b/snap/local/usr/bin/signal-desktop-wrapper
@@ -18,7 +18,6 @@ fi
 
 if [[ "${wayland_native}" == "true" ]]; then
     opts+=(
-        "--enable-features=UseOzonePlatform"
         "--enable-features=WaylandWindowDecorations"
         "--ozone-platform=wayland"
     )

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -233,18 +233,18 @@ apps:
     extensions: [gnome]
     command: usr/bin/signal-desktop-wrapper
     plugs:
+      - audio-playback
+      - audio-record
       - browser-support
       - camera
+      - desktop
+      - desktop-legacy
       - home
       - network
       - opengl
-      - audio-playback
-      - audio-record
       - removable-media
-      - unity7
-      - desktop
-      - desktop-legacy
       - screen-inhibit-control
+      - unity7
     environment:
       GTK_USE_PORTAL: "1"
       TMPDIR: $XDG_RUNTIME_DIR

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -245,6 +245,7 @@ apps:
       - removable-media
       - screen-inhibit-control
       - unity7
+      - wayland
     environment:
       GTK_USE_PORTAL: "1"
       TMPDIR: $XDG_RUNTIME_DIR


### PR DESCRIPTION
This is an experiment to see about adding an option that forces Signal Desktop to run under wayland using the ozone patches.

My experience with Signal Desktop on wayland has been pretty poor over the last two years (in fact it's one of the only apps I still run under Xwayland). This build also exhibits the same issues I've seen elsewhere when this is enabled. The most annoying behaviour is that when you start Signal, it goes into the background, and until you hit the launcher again it doesn't appear.

I haven't been able to fix this behaviour anywhere else, but I'll put this up for discussion in case anyone has some ideas.

Fixes #209.