### PR TITLE
Update test-snap-can-build.yml

### DIFF
--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -15,7 +15,10 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        node-version: [16.x]
+        
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Updated test-snap-can-build.yaml to node16 to suppress "[annotation](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)" at end of action.