### PR TITLE
Bug: Fix store formatting

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,9 +17,8 @@ description: |
 
   Per the request of the Signal developers, this snap does not use the system tray by default. This is disabled by default per the request of the Signal developers, because system tray support is not stable. Set to `false`, Signal will stop when you close it and will not have a system tray icon. You can enable it by running the following command.
 
-  ```
-  snap set signal-desktop tray-icon=true
-  ```
+      snap set signal-desktop tray-icon=true
+  
 
   **Are you having issues?**
 


### PR DESCRIPTION
The text for `snap set` uses a markdown which isn't supported in the store.