### PR TITLE
fix: read the correct node version from the package.json

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,10 +67,12 @@ parts:
     plugin: dump
     source: https://github.com/asdf-vm/asdf.git
     source-tag: v0.13.1
-    build-environment:
-      - NODE_VERSION: 18.15.0
+    build-packages:
+      - jq
     override-build: |
       source "./asdf.sh"
+
+      NODE_VERSION="$(curl "https://raw.githubusercontent.com/signalapp/Signal-Desktop/v${SNAPCRAFT_PROJECT_VERSION}/package.json" | jq -r '.engines.node')"
 
       # Install the correct version of nodejs required by Signal-Desktop
       asdf plugin add nodejs


### PR DESCRIPTION
The latest version bump (v6.42.0) included an update to the Node version specified. Signal Desktop is quite specific about the version of node used, and previously this was hardcoded. This led to a [failure](https://github.com/snapcrafters/signal-desktop/actions/runs/7219975046/job/19672809676#step:2:1811) in CI.

This change fetches the `package.json` for the version being built and reads the expected node version so that it can be installed with `asdf`, and should prevent similar failures in the future.