### PR TITLE
fix: ensure that locales are generated per upstream package change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ squashfs-root
 # filenames by default.
 screenshot-screen.png
 screenshot-window.png
+
+# remote-build logs
+signal-desktop_*.txt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -153,7 +153,9 @@ parts:
       # that apart into its component parts.
       yarn build-protobuf
       yarn build:esbuild
-      yarn sass 
+      yarn build:icu-types
+      yarn build:compact-locales
+      yarn sass
       yarn get-expire-time
       yarn copy-components
 


### PR DESCRIPTION
Upstream seem to have changed the build process a little, which has resulted in failures such as those seen in #281.

I think the relevant commit upstream is this one: https://github.com/signalapp/Signal-Desktop/commit/f55e6e3407d88079867b7de576e8573e0cdeab8c

This change adds the new steps to `yarn generate` which we run manually due to issues with `npm run-all`.