### PR TITLE
build: update to use `core24`

### DIFF
--- a/snap/local/usr/bin/signal-desktop-wrapper
+++ b/snap/local/usr/bin/signal-desktop-wrapper
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Run the configure hook which sets defaults for any config options
-"${SNAP}/snap/hooks/configure"
+"${SNAP}/meta/hooks/configure"
 
 # Grab the config options
 tray_icon="$(snapctl get tray-icon)"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -171,13 +171,11 @@ parts:
       - libxss1
       - libnspr4
       - libnss3
-      - libvips42
     prime:
       - opt
       - usr/share
       - usr/lib/*/libxss*
       - usr/lib/*/*nss*
-      - usr/lib/*/libvips*
       - usr/lib/*/libI*
       - usr/lib/*/libMagic*
       - usr/lib/*/libcfit*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,14 +36,14 @@ adopt-info: signal-desktop
 icon: snap/gui/signal-desktop.png
 version: 7.18.0
 
-base: core22
+base: core24
 grade: stable
 confinement: strict
 compression: lzo
 
-architectures:
-  - amd64
-  - arm64
+platforms:
+  amd64:
+  arm64:
 
 parts:
   nodejs:
@@ -212,10 +212,10 @@ parts:
   cleanup:
     after: [signal-desktop]
     plugin: nil
-    build-snaps: [gnome-42-2204]
+    build-snaps: [gnome-46-2404]
     override-prime: |
       set -eux
-      cd /snap/gnome-42-2204/current
+      cd /snap/gnome-46-2404/current
       find . -type f,l -exec rm -f $CRAFT_PRIME/{} \;
       for CRUFT in bug lintian man; do
         rm -rf $CRAFT_PRIME/usr/share/$CRUFT


### PR DESCRIPTION
This PR updates the snap to use core24. Iv'e given it a good test locally, and all seems to be fine!

![screenshot-20240801-124849](https://github.com/user-attachments/assets/a6672a2b-ae62-4642-95b8-709729bc6608)
