### PR TITLE
build: enable the `build:dns-fallback` step from `npm run generate`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ screenshot-window.png
 
 # remote-build logs
 signal-desktop_*.txt
+snapcraft-signal-desktop*.txt

--- a/snap/patches/dns-fallback-use-resolve.patch
+++ b/snap/patches/dns-fallback-use-resolve.patch
@@ -1,0 +1,83 @@
+diff --git a/ts/scripts/generate-dns-fallback.ts b/ts/scripts/generate-dns-fallback.ts
+index 39f442f4b..f204fe784 100644
+--- a/ts/scripts/generate-dns-fallback.ts
++++ b/ts/scripts/generate-dns-fallback.ts
+@@ -1,15 +1,15 @@
+ // Copyright 2024 Signal Messenger, LLC
+ // SPDX-License-Identifier: AGPL-3.0-only
+ 
+-import { join } from 'path';
+-import { lookup as lookupCb } from 'dns';
++import { resolve4 as resolve4Cb, resolve6 as resolve6Cb } from 'dns';
+ import { writeFile } from 'fs/promises';
++import { join } from 'path';
+ import { promisify } from 'util';
+-import type { ResolvedEndpoint } from 'electron';
+ 
+ import { isNotNil } from '../util/isNotNil';
+ 
+-const lookup = promisify(lookupCb);
++const resolve4 = promisify(resolve4Cb);
++const resolve6 = promisify(resolve6Cb);
+ 
+ const FALLBACK_DOMAINS = [
+   'chat.signal.org',
+@@ -25,35 +25,31 @@ const FALLBACK_DOMAINS = [
+ async function main() {
+   const config = await Promise.all(
+     FALLBACK_DOMAINS.sort().map(async domain => {
+-      const addresses = await lookup(domain, { all: true });
+ 
+-      const endpoints = addresses
+-        .map(({ address, family }): ResolvedEndpoint | null => {
+-          if (family === 4) {
+-            return { family: 'ipv4', address };
+-          }
+-          if (family === 6) {
+-            return { family: 'ipv6', address };
+-          }
+-          return null;
+-        })
+-        .filter(isNotNil)
+-        .sort((a, b) => {
+-          if (a.family < b.family) {
+-            return -1;
+-          }
+-          if (a.family > b.family) {
+-            return 1;
+-          }
++      const ipv4endpoints = (await resolve4(domain))
++        .map(a => ({"family": "ipv4", "address": a}))
++
++      const ipv6endpoints = (await resolve6(domain))
++        .map(a => ({"family": "ipv6", "address": a}))
++
++      const endpoints = [...ipv4endpoints, ...ipv6endpoints]
++      .filter(isNotNil)
++      .sort((a, b) => {
++        if (a.family < b.family) {
++          return -1;
++        }
++        if (a.family > b.family) {
++          return 1;
++        }
+ 
+-          if (a.address < b.address) {
+-            return -1;
+-          }
+-          if (a.address > b.address) {
+-            return 1;
+-          }
+-          return 0;
+-        });
++        if (a.address < b.address) {
++          return -1;
++        }
++        if (a.address > b.address) {
++          return 1;
++        }
++        return 0;
++      })
+ 
+       return { domain, endpoints };
+     })

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -153,6 +153,7 @@ parts:
       npm run build-protobuf
       npm run build:esbuild
       npm run build:icu-types
+      npm run build:dns-fallback
       npm run build:compact-locales
       npm run sass
       npm run get-expire-time

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -192,13 +192,10 @@ apps:
       - camera
       - home
       - network
-      - opengl
       - audio-playback
       - audio-record
       - removable-media
       - unity7
-      - desktop
-      - desktop-legacy
       - screen-inhibit-control
     environment:
       GTK_USE_PORTAL: "1"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -114,7 +114,6 @@ parts:
       - jq
       - moreutils
       - python3
-      - wget
     build-environment:
       - SIGNAL_ENV: "production"
     override-build: |
@@ -174,37 +173,7 @@ parts:
       # and 'linux-arm64-unpacked' for arm64.
       mkdir -p "${CRAFT_PART_INSTALL}/opt"
       mv release/linux-*unpacked "${CRAFT_PART_INSTALL}/opt/Signal"
-    stage-packages:
-      - libxss1
-      - libnspr4
-      - libnss3
     prime:
-      - opt
-      - usr/share
-      - usr/lib/*/libxss*
-      - usr/lib/*/*nss*
-      - usr/lib/*/libI*
-      - usr/lib/*/libMagic*
-      - usr/lib/*/libcfit*
-      - usr/lib/*/libcgif*
-      - usr/lib/*/libexif*
-      - usr/lib/*/libfftw*
-      - usr/lib/*/libgsf*
-      - usr/lib/*/libheif*
-      - usr/lib/*/libimage*
-      - usr/lib/*/libmat*
-      - usr/lib/*/libopensli*
-      - usr/lib/*/libwebp*
-      - usr/lib/*/libHalf*
-      - usr/lib/*/libaom*
-      - usr/lib/*/libdav1d*
-      - usr/lib/*/libx265*
-      - usr/lib/*/libhdf*
-      - usr/lib/*/libsz*
-      - usr/lib/*/liblqr*
-      - usr/lib/*/libaec*
-      - usr/lib/*/libde265*
-      - usr/lib/*/libnuma*
       - -opt/Signal/chrome-sandbox
       - -opt/Signal/resources/app.asar.unpacked/node_modules/sharp/vendor/lib
       - -opt/Signal/resources/app.asar.unpacked/node_modules/sharp/vendor/include
@@ -213,19 +182,6 @@ parts:
     plugin: dump
     source: ./snap/local
     source-type: local
-
-  cleanup:
-    after: [signal-desktop]
-    plugin: nil
-    build-snaps: [gnome-46-2404]
-    override-prime: |
-      set -eux
-      cd /snap/gnome-46-2404/current
-      find . -type f,l -exec rm -f $CRAFT_PRIME/{} \;
-      for CRUFT in bug lintian man; do
-        rm -rf $CRAFT_PRIME/usr/share/$CRUFT
-      done
-      find $CRAFT_PRIME/usr/share/doc/ -type f -not -name 'copyright' -delete
 
 apps:
   signal-desktop:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -132,6 +132,12 @@ parts:
 
       git lfs install
 
+      # When running `npm run build:dns-fallback`, the code tries to use `dns.lookup` from
+      # the NodeJS standard library, which makes a `getaddrinfo` syscall to try and resolve
+      # domain names, which seems to fail on Launchpad builders. This patch replaces the
+      # logic to use `dns.resolve4` and `dns.resolve6` instead.
+      git apply $CRAFT_PROJECT_DIR/snap/patches/dns-fallback-use-resolve.patch
+
       # Update the package.json so the build uses the patched libraries
       cat package.json \
         | jq -r --arg f "file:${PWD}/../../better-sqlite3/build" '.dependencies."@signalapp/better-sqlite3"=$f' \


### PR DESCRIPTION
This PR is broken into a few commits:

1. Ignore the paths of the new `snapcraft remote-build` logs
2. Enable a build step we were previously skipping due to proxy issues; this required an actual patch to the source, which I will propose upstream
3. Remove some older build patterns/cleanup stuff
4. Add the x11/wayland plugs - not sure why these weren't already in!