### PR TITLE
fix: patch fs-extra to fix images on arm64

### DIFF
--- a/snap/patches/fs-extra+5.0.0.patch
+++ b/snap/patches/fs-extra+5.0.0.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/fs-extra/lib/ensure/file.js b/node_modules/fs-extra/lib/ensure/file.js
+index 67eed30..7b115a2 100644
+--- a/node_modules/fs-extra/lib/ensure/file.js
++++ b/node_modules/fs-extra/lib/ensure/file.js
+@@ -8,8 +8,14 @@ const pathExists = require('../path-exists').pathExists
+ 
+ function createFile (file, callback) {
+   function makeFile () {
++    console.log(`Going to create empty file/dir ${file}`)
+     fs.writeFile(file, '', err => {
+-      if (err) return callback(err)
++      if (err && process.platform === 'linux' && process.arch === 'arm64') {
++        console.log(`Error while creating empty file, ignoring: ${err}`)
++      } else if (err) {
++        console.log(err)
++        return callback(err)
++      }
+       callback()
+     })
+   }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -142,6 +142,10 @@ parts:
       npm run build
       popd
 
+      # Add a patch that fixes the rendering of images on arm64 builds.
+      # See: https://github.com/snapcrafters/signal-desktop/issues/279#issuecomment-2372021170
+      cp $CRAFT_PROJECT_DIR/snap/patches/fs-extra+5.0.0.patch patches/fs-extra+5.0.0.patch
+
       # Install the dependencies for the Signal-Desktop application.
       npm install --legacy-peer-deps
 


### PR DESCRIPTION
Fixes #279 

Adds a patch to the build which reportedly fixes an issue rendering images on arm64.

@CarstenKochElsdorf perhaps you could build & test?