### PR TITLE
fix: use `--password-store=basic` when launching Signal

### DIFF
--- a/snap/local/usr/bin/signal-desktop-wrapper
+++ b/snap/local/usr/bin/signal-desktop-wrapper
@@ -16,7 +16,7 @@ opts=(
     # snap/flatpak environments, which means that Signal loses access to the encryption
     # key used to encrypt the local database, and needs to be re-linked (losing all message
     # history) every time it's launched.
-    "--password-store="basic"
+    "--password-store=basic"
 )
 
 # If the the tray icon is enabled, add to the list of command line args

--- a/snap/local/usr/bin/signal-desktop-wrapper
+++ b/snap/local/usr/bin/signal-desktop-wrapper
@@ -8,7 +8,16 @@ set -euo pipefail
 tray_icon="$(snapctl get tray-icon)"
 
 # Define an array of command line options
-opts=()
+opts=(
+    # Don't run the chrome sandbox inside the snap environment, rely on AppArmor confinement
+    "--no-sandbox"
+    # See https://github.com/snapcrafters/signal-desktop/issues/300
+    # An upstream Chrome issue blocks the correct inovation of libsecret from within
+    # snap/flatpak environments, which means that Signal loses access to the encryption
+    # key used to encrypt the local database, and needs to be re-linked (losing all message
+    # history) every time it's launched.
+    "--password-store="basic"
+)
 
 # If the the tray icon is enabled, add to the list of command line args
 if [[ "${tray_icon}" == "true" ]]; then
@@ -16,4 +25,4 @@ if [[ "${tray_icon}" == "true" ]]; then
 fi
 
 # Run signal-desktop with the gathered arguments
-exec "${SNAP}/opt/Signal/signal-desktop" "--no-sandbox" "${opts[@]}" "$@"
+exec "${SNAP}/opt/Signal/signal-desktop" "${opts[@]}" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -194,7 +194,6 @@ apps:
       - removable-media
       - unity7
       - screen-inhibit-control
-      - password-manager-service
     environment:
       TMPDIR: $XDG_RUNTIME_DIR
       # Included temporarily until https://github.com/snapcore/snapcraft-desktop-integration/issues/28


### PR DESCRIPTION
Fixes #300 🥳 

Start Signal with `--password-store=basic` and prevent it from trying to use `gnome-libsecret`, which as far as I can tell is broken in the Chrome implementation, inherited by Electron, and thus meaning that Signal keeps losing access to the encryption key for its database!

This solution *is less secure*, but without it, Signal literally doesn't work on some platforms. The introduction of the `safeStorage` API in Signal is relatively recent, and fraught with issues on multiple platforms:

- https://github.com/signalapp/Signal-Desktop/issues/6970
- https://github.com/signalapp/Signal-Desktop/issues/7029
- https://github.com/signalapp/Signal-Desktop/issues/7005

It appears to be broken in the Snap, Flatpak, official Deb and even on Windows - though this doesn't seem to be acknowledged by Signal.

My proposition is we merge this fix, and keep and eye on changes upstream, potentially removing this workaround once we have confidence it'll work!

Further info:

- https://www.electronjs.org/docs/latest/api/safe-storage#safestoragegetselectedstoragebackend-linux
- https://issues.chromium.org/issues/370535829