### PR TITLE
fix: add dbus interface to freedesktop secrets

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -180,6 +180,12 @@ parts:
     source: ./snap/local
     source-type: local
 
+plugs:
+  dbus-secrets:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.secrets
+
 apps:
   signal-desktop:
     extensions: [gnome]
@@ -194,7 +200,7 @@ apps:
       - removable-media
       - unity7
       - screen-inhibit-control
-      - password-manager-service
+      - dbus-secrets
     environment:
       TMPDIR: $XDG_RUNTIME_DIR
       # Included temporarily until https://github.com/snapcore/snapcraft-desktop-integration/issues/28


### PR DESCRIPTION
An alternative approach to solving #300, which is likely more secure, if it'll work!

To test this:

```
git clone https://github.com/jnsgruk/signal-desktop -b secrets-dbus
cd signal-desktop
snapcraft pack --verbose

# CAUTION: THIS WILL REMOVE YOUR HISTORY
sudo snap remove signal-desktop --purge

sudo snap install --dangerous ./signal-desktop*snap
sudo snap connect signal-desktop:dbus-secrets
```

Try to link Signal, then close it and re-open it.