### PR TITLE
fix: stage libnss

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -166,6 +166,8 @@ parts:
       # and 'linux-arm64-unpacked' for arm64.
       mkdir -p "${CRAFT_PART_INSTALL}/opt"
       mv release/linux-*unpacked "${CRAFT_PART_INSTALL}/opt/Signal"
+    stage-packages:
+      - libnss3
     prime:
       - -opt/Signal/chrome-sandbox
       - -opt/Signal/resources/app.asar.unpacked/node_modules/sharp/vendor/lib


### PR DESCRIPTION
This change ensures that `libnss` is staged as part of the snap build.

I think this will Fix #325