### PR TITLE
fix: use signal-desktop for desktop file and WM class

### DIFF
--- a/snap/patches/ask-default.patch
+++ b/snap/patches/ask-default.patch
@@ -1,0 +1,24 @@
+diff --git a/app/main.main.ts b/app/main.main.ts
+index fe3a4b9a8..2d10750e5 100644
+--- a/app/main.main.ts
++++ b/app/main.main.ts
+@@ -2639,9 +2639,16 @@ app.on(
+   }
+ );
+ 
+-app.setAsDefaultProtocolClient('sgnl');
+-app.setAsDefaultProtocolClient('signalcaptcha');
+-
++if (!app.isDefaultProtocolClient('sgnl')) {
++  app.setAsDefaultProtocolClient('sgnl');
++} else {
++  log.info('App is already registered as the default app for the sgnl url scheme.');
++}
++if (!app.isDefaultProtocolClient('signalcaptcha')) {
++  app.setAsDefaultProtocolClient('signalcaptcha');
++} else {
++  log.info('App is already registered as the default app for the signalcaptcha url scheme.');
++}
+ ipc.on(
+   'set-badge',
+   (_event: Electron.Event, badge: number | 'marked-unread') => {

--- a/snap/patches/production-desktop-name.patch
+++ b/snap/patches/production-desktop-name.patch
@@ -1,0 +1,22 @@
+diff --git a/package.json b/package.json
+index 874f2e040..4e2067fd8 100644
+--- a/package.json
++++ b/package.json
+@@ -4,7 +4,7 @@
+   "name": "signal-desktop",
+   "productName": "Signal",
+   "description": "Private messaging from your desktop",
+-  "desktopName": "signal.desktop",
++  "desktopName": "signal-desktop.desktop",
+   "repository": "https://github.com/signalapp/Signal-Desktop.git",
+   "version": "8.3.0-alpha.1",
+   "license": "AGPL-3.0-only",
+@@ -522,7 +522,7 @@
+       "category": "Network;InstantMessaging;Chat",
+       "desktop": {
+         "entry": {
+-          "StartupWMClass": "signal"
++          "StartupWMClass": "signal-desktop"
+         }
+       },
+       "artifactName": "${name}_${version}_${arch}.${ext}",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -81,6 +81,10 @@ parts:
       # Apply patches
       cat package.json | jq -r --arg fs_extra patches/fs-extra+11.2.0.patch '.pnpm.patchedDependencies."fs-extra"=$fs_extra ' | sponge package.json
       patch -p1 <patches/production-desktop-name.patch
+      # This patch checks if Signal is the default app for URL protocols
+      # before trying to become the default. Reduces snapd settings change reqs.
+      # https://github.com/signalapp/Signal-Desktop/issues/7736
+      patch -p1 <patches/ask-default.patch
 
       # Install the dependencies for the Signal-Desktop application.
       pnpm install

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,6 +80,7 @@ parts:
 
       # Apply patches
       cat package.json | jq -r --arg fs_extra patches/fs-extra+11.2.0.patch '.pnpm.patchedDependencies."fs-extra"=$fs_extra ' | sponge package.json
+      patch -p1 <patches/production-desktop-name.patch
 
       # Install the dependencies for the Signal-Desktop application.
       pnpm install


### PR DESCRIPTION
The first commit fixes #142 but results in snapd excessively asking to allow settings changes.

The second commit chills Signal out by having it only request those settings changes when Signal isn't already the default handler for those schemes.