### PR TITLE
fix: install pnpm outside signal workspace

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,13 +46,28 @@ platforms:
   arm64:
 
 parts:
+  node-runtime:
+    plugin: nil
+    build-packages:
+      - curl
+    override-build: |
+      # Install pnpm in a dedicated part so Signal's workspace hooks are not
+      # loaded while bootstrapping pnpm itself.
+      export PNPM_HOME="${CRAFT_PART_INSTALL}/pnpm"
+      export PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
+      curl -fsSL https://get.pnpm.io/install.sh -o /tmp/install-pnpm.sh
+      (cd /tmp && env SHELL=bash sh /tmp/install-pnpm.sh)
+    prime:
+      - -*
+
   signal-desktop:
+    after:
+      - node-runtime
     plugin: dump
     source: https://github.com/signalapp/Signal-Desktop
     source-type: git
     source-tag: v$SNAPCRAFT_PROJECT_VERSION
     build-packages:
-      - curl
       - execstack
       - git-lfs
       - jq
@@ -62,12 +77,12 @@ parts:
       - SIGNAL_ENV: "production"
       - ELECTRON_GET_USE_PROXY: "1"
     override-build: |
-      # Install pnpm and the correct version of nodejs
-      export PNPM_HOME="/root/.local/share/pnpm"
-      export PATH="$PNPM_HOME:$PATH"
+      export PNPM_HOME="${CRAFT_STAGE}/pnpm"
+      export PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
       PNPM_VERSION="$(jq -r '.packageManager // empty' package.json | sed 's/pnpm@//')"
-      curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION="${PNPM_VERSION}" SHELL=bash sh -
+      pnpm self-update "${PNPM_VERSION}"
       pnpm env use --global "$(jq -r .engines.node package.json)"
+      pnpm add --global npm
 
       git lfs install
 


### PR DESCRIPTION
## Summary
- Add a separate `node-runtime` part that bootstraps pnpm before the Signal source tree is involved.
- Keep the Signal package.json-dependent steps in the `signal-desktop` part: pin pnpm to `packageManager`, install the requested Node version from `engines.node`, and add npm for Signal's lifecycle scripts.
- Point the Signal build at the staged runtime via `$CRAFT_STAGE/pnpm/bin` and keep the build-only runtime out of the final snap with `prime: ["-*"]`.

## Repro / Test Plan
- Reproduced the original Release failure locally against Signal Desktop v8.16.0: the old inline pnpm install from the source tree fails with `/bin/sh: 1: pnpm: not found` from `.pnpmfile.mjs`.
- Ran `python3` YAML parse for `snap/snapcraft.yaml`.
- Ran `git diff --check`.
- Ran `snapcraft expand-extensions`.
- Ran `snapcraft clean signal-desktop node-runtime && snapcraft build signal-desktop --use-lxd` successfully.
- Ran `snapcraft clean && snapcraft pack --use-lxd` successfully, producing `signal-desktop_8.16.0_amd64.snap`.
- Verified the packed snap does **not** include pnpm/npm build tooling: `unsquashfs -ll signal-desktop_8.16.0_amd64.snap | grep -E '(^|/)(pnpm|pnpx|pn|npm|npx|node)( |$|/)'` returned no matches, and a broader grep for `pnpm|node-runtime|\.local/share/pnpm|node_modules/(npm|@pnpm)` also returned no matches.
- PR CI: `🧪 Build snap on amd64` passed on the latest pushed commit.

@jnsgruk