### PR TITLE
fix ARM64 image patch registration for pnpm 11

### DIFF
--- a/snap/scripts/add-pnpm-patch.mjs
+++ b/snap/scripts/add-pnpm-patch.mjs
@@ -1,0 +1,65 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const signalRoot = process.cwd();
+const workspacePath = path.join(signalRoot, "pnpm-workspace.yaml");
+const extraPatch = {
+  key: "fs-extra@11.3.4",
+  packageName: "fs-extra",
+  path: "patches/fs-extra+11.3.4.patch",
+};
+
+if (!existsSync(workspacePath)) {
+  throw new Error(
+    `Expected ${workspacePath} to exist. Has Signal's workspace layout changed?`,
+  );
+}
+
+const original = readFileSync(workspacePath, "utf8");
+const headers = [...original.matchAll(/^patchedDependencies[ \t]*:[ \t]*$/gm)];
+
+if (headers.length !== 1) {
+  throw new Error(
+    `Expected exactly one top-level patchedDependencies block in ${workspacePath}; found ${headers.length}.`,
+  );
+}
+
+const blockStart = headers[0].index + headers[0][0].length;
+const blockLines = original.slice(blockStart).split("\n");
+
+for (const line of blockLines) {
+  if (line.trim() === "") {
+    continue;
+  }
+  if (!/^\s/.test(line)) {
+    break;
+  }
+
+  const entry = line.match(/^\s+(?:(['"])(.*?)\1|([^#'"][^:#]*?))[ \t]*:/);
+  if (!entry) {
+    continue;
+  }
+
+  const key = (entry[2] ?? entry[3]).trim();
+  const separator = key.lastIndexOf("@");
+  const packageName = separator > 0 ? key.slice(0, separator) : key;
+
+  if (packageName === extraPatch.packageName) {
+    throw new Error(
+      `${workspacePath} already patches ${extraPatch.packageName}. ` +
+        "Reconcile Signal's patch with the Snap patch instead of duplicating it.",
+    );
+  }
+}
+
+const patchPath = path.join(signalRoot, extraPatch.path);
+if (!existsSync(patchPath)) {
+  throw new Error(`Expected Snap patch ${patchPath} to exist.`);
+}
+
+const entry = `\n  '${extraPatch.key}': '${extraPatch.path}'`;
+const merged =
+  original.slice(0, blockStart) + entry + original.slice(blockStart);
+
+writeFileSync(workspacePath, merged, "utf8");
+console.log(`Registered ${extraPatch.key} in ${workspacePath}`);

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,7 +71,6 @@ parts:
       - execstack
       - git-lfs
       - jq
-      - moreutils
       - python3
     build-environment:
       - SIGNAL_ENV: "production"
@@ -86,24 +85,35 @@ parts:
 
       git lfs install
 
-      # Build the sticker-creator
-      pnpm -C ./sticker-creator/ install
-      pnpm -C ./sticker-creator/ run build
-
       # Add a patch that fixes the rendering of images on arm64 builds.
       # See: https://github.com/snapcrafters/signal-desktop/issues/279#issuecomment-2372021170
-      cp $CRAFT_PROJECT_DIR/snap/patches/* patches/
+      cp "$CRAFT_PROJECT_DIR"/snap/patches/* patches/
 
-      # Apply patches
-      cat package.json | jq -r --arg fs_extra patches/fs-extra+11.3.4.patch '.pnpm.patchedDependencies."fs-extra@11.3.4"=$fs_extra ' | sponge package.json
-      patch -p1 <patches/production-desktop-name.patch
+      # pnpm 11 only reads patchedDependencies from pnpm-workspace.yaml. Merge
+      # our patch into Signal's existing block before any workspace install.
+      node "$CRAFT_PROJECT_DIR/snap/scripts/add-pnpm-patch.mjs"
+
+      # Apply source patches.
+      patch -p1 < patches/production-desktop-name.patch
+
+      # Build the sticker-creator
+      pnpm -C ./sticker-creator/ install --no-frozen-lockfile
+      pnpm -C ./sticker-creator/ run build
 
       # Ensure node-gyp is available for native addon builds (installed via
       # pnpm so that it lands in $PNPM_HOME, which is already on PATH).
       pnpm add -g node-gyp
 
       # Install the dependencies for the Signal-Desktop application.
-      pnpm install
+      pnpm install --no-frozen-lockfile
+
+      # Fail if pnpm silently ignores the fs-extra patch.
+      FS_EXTRA_FILE="$(node -p "require('node:path').join(require('node:path').dirname(require.resolve('fs-extra')), 'ensure/file.js')")"
+      if ! grep -Fq "most likely been created just fine" "$FS_EXTRA_FILE"; then
+        echo "ERROR: fs-extra workaround was not applied to $FS_EXTRA_FILE" >&2
+        exit 1
+      fi
+
       pnpm run generate
        
       # This is the equivalent of 'npm run build-linux' with some adjustments


### PR DESCRIPTION
## Summary

- register `fs-extra@11.3.4` in Signal's existing `pnpm-workspace.yaml` `patchedDependencies` block
- apply the workspace configuration before the sticker-creator and main installs
- allow both installs to regenerate the lockfile
- fail loudly when Signal's workspace layout or patch ownership changes
- assert after installation that the ARM64 `fs-extra` workaround was actually applied

## Root cause

Signal Desktop 8.16 and later use pnpm 11, which no longer reads `patchedDependencies` from the `pnpm` field in `package.json`. The Snap build therefore completed without applying the existing `fs-extra` workaround, causing image loading to regress on environments such as ARM64 Crostini.

## Validation

Validated against Signal Desktop v8.20.0 with Node 24.17.0 and pnpm 11.5.2:

- preserved all 15 upstream workspace patch entries and added `fs-extra@11.3.4` exactly once
- confirmed `package.json` is not used for patch registration
- completed sticker-creator and main dependency installs
- confirmed the installed `fs-extra/lib/ensure/file.js` contains the patched `makeFile` implementation and diagnostic string
- confirmed the generated lockfile records the patched dependency and patch hash
- completed the sticker-creator build, `pnpm run generate`, and the production rolldown build
- passed Prettier, Node syntax, `git diff --check`, failure-mode checks, and Snapcraft extension expansion

A complete Snap package build and native ARM64/Crostini execution were not performed locally.

Fixes #460.
