### PR TITLE
fix: backport xmldom deprecation allowance

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,6 +93,11 @@ parts:
       # our patch into Signal's existing block before any workspace install.
       node "$CRAFT_PROJECT_DIR/snap/scripts/add-pnpm-patch.mjs"
 
+      # Backport Signal's v8.24 allowance for xmldom versions already present
+      # in the v8.23 lockfile. This is a no-op once upstream includes the fix.
+      sed -i "s/'@xmldom\/xmldom': '0.8.10'/'@xmldom\/xmldom': '0.8.13 || 0.9.10'/" pnpm-workspace.yaml
+      grep -Fq "'@xmldom/xmldom': '0.8.13 || 0.9.10'" pnpm-workspace.yaml
+
       # Apply source patches.
       patch -p1 < patches/production-desktop-name.patch
 


### PR DESCRIPTION
## Summary

- backport Signal Desktop's updated `@xmldom/xmldom` deprecation allowance from the 8.24 branch
- keep the recipe compatible with 8.23.0 and future releases where upstream already contains the allowance
- fail closed if neither the old nor corrected workspace entry is present

## Root cause

The 8.23.0 release build fails during the sticker creator dependency install because Signal's `.pnpmfile.mjs` rejects deprecated packages. Its lockfile contains `@xmldom/xmldom` 0.8.13 and 0.9.10, while `pnpm-workspace.yaml` only allows 0.8.10.

This is not caused by a dependency change between Signal Desktop 8.22.0 and 8.23.0: both releases contain the same xmldom versions and the same stale allowance. The 8.22.0 Snap build succeeded on 6 August, before the registry metadata caused pnpm to flag these versions; the 8.23.0 build failed on 15 August.

Signal fixed this upstream on the 8.24 branch in commit [6773296](https://github.com/signalapp/Signal-Desktop/commit/6773296167094f520c74fb157b5ce8d6caec40cf), changing the allowance to `0.8.13 || 0.9.10`. This recipe applies the same change when building 8.23.0 and becomes a no-op once the upstream source contains it.

## Validation

Tested against Signal Desktop v8.23.0 with Node 24.17.0 and pnpm 11.5.2:

- reproduced the reported failure after registering the Snap's `fs-extra` patch: both xmldom versions were rejected by `.pnpmfile.mjs`
- applied the recipe change and completed `pnpm -C ./sticker-creator/ install --no-frozen-lockfile`
- completed the sticker creator production build
- confirmed the existing `fs-extra` patch remains applied
- confirmed the transform succeeds exactly once against both v8.23.0 and v8.24.0-beta.1
- parsed `snap/snapcraft.yaml` with PyYAML and passed `git diff --check`

A complete Snap package build and native runtime test were not performed locally; PR CI runs the managed amd64 build.

@jnsgruk
